### PR TITLE
Using attr_accessible for Slug attributes

### DIFF
--- a/lib/friendly_id/active_record_adapter/slug.rb
+++ b/lib/friendly_id/active_record_adapter/slug.rb
@@ -1,6 +1,8 @@
 # A Slug is a unique, human-friendly identifier for an ActiveRecord.
 class Slug < ::ActiveRecord::Base
-
+  
+  attr_accessible :name, :scope, :sluggable, :sequence
+  
   def self.named_scope(*args, &block) scope(*args, &block) end if FriendlyId.on_ar3?
   table_name = "slugs"
   belongs_to :sluggable, :polymorphic => true


### PR DESCRIPTION
The ActiveRecord `Slug` model doesn't specify accessible attributes, preventing the record from being saved when model attributes have been set to protected by default, eg, using `ActiveRecord::Base.send(:attr_accessible, nil)` in a Rails initializer. This commit uses the `attr_accessible` macro to specify whitelisted attributes on `Slug`. All existing tests pass.
