### PR TITLE
Fix a bug that causes the rake task friendly_id:remove_old_slugs MODEL=XXX to abort

### DIFF
--- a/lib/friendly_id/active_record_adapter/slug.rb
+++ b/lib/friendly_id/active_record_adapter/slug.rb
@@ -19,7 +19,7 @@ class Slug < ::ActiveRecord::Base
     sluggable_id && !@sluggable and begin
       klass = sluggable_type.constantize
       klass.send(:with_exclusive_scope) do
-        @sluggable = klass.find(sluggable_id.to_i)
+        @sluggable = klass.find(sluggable_id.to_i) rescue nil
       end
     end
     @sluggable
@@ -27,7 +27,7 @@ class Slug < ::ActiveRecord::Base
 
   # Whether this slug is the most recent of its owner's slugs.
   def current?
-    sluggable.slug == self
+    sluggable.present? && sluggable.slug == self
   end
 
   def outdated?


### PR DESCRIPTION
The rake task aborts if one or more instances of the MODEL has been deleted from the db. I added a check to handle that condition so the task can continue.
