### PR TITLE
Rubygems has a deprecation warning on the current gemspec, fixed it with this commit.

### DIFF
--- a/friendly_id.gemspec
+++ b/friendly_id.gemspec
@@ -11,7 +11,6 @@ Gem::Specification.new do |s|
   s.files             = Dir["lib/**/*.rb", "lib/**/*.rake", "*.md", "MIT-LICENSE",
     "Rakefile", "rails/init.rb", "generators/**/*.*", "test/**/*.*",
     "extras/**/*.*", ".gemtest"]
-  s.has_rdoc          = true
   s.homepage          = "http://norman.github.com/friendly_id"
   s.name              = "friendly_id"
   s.platform          = Gem::Platform::RUBY


### PR DESCRIPTION
Fixes Rubygems deprecation: 'NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2011-10-01. Gem::Specification#has_rdoc= called from friendly_id.gemspec:14'.
