### PR TITLE
Rake task fix

### DIFF
--- a/lib/friendly_id/active_record_adapter/tasks.rb
+++ b/lib/friendly_id/active_record_adapter/tasks.rb
@@ -30,7 +30,7 @@ module FriendlyId
         :include => :slug,
         :limit   => (ENV["LIMIT"] || 100).to_i,
         :offset  => 0,
-        :order   => ENV["ORDER"] || "#{klass.table_name}.id ASC",
+        :order   => ENV["ORDER"] || "#{klass.table_name}.#{klass.primary_key} ASC",
       }.merge(task_options || {})
 
       while records = find(:all, options) do


### PR DESCRIPTION
I've fixed a rake task which failed when using a different primary key than 'id', I've just set it to use klass.primary_key instead, works well for me
