### PR TITLE
support for allow_blank

### DIFF
--- a/lib/friendly_id/active_record_adapter/simple_model.rb
+++ b/lib/friendly_id/active_record_adapter/simple_model.rb
@@ -48,7 +48,7 @@ module FriendlyId
       end
 
       def skip_friendly_id_validations
-        friendly_id.nil? && friendly_id_config.allow_nil?
+        (friendly_id.nil? && friendly_id_config.allow_nil?) || (friendly_id.blank? && friendly_id_config.allow_blank?)
       end
 
       def validate_friendly_id

--- a/lib/friendly_id/configuration.rb
+++ b/lib/friendly_id/configuration.rb
@@ -23,6 +23,7 @@ module FriendlyId
 
     DEFAULTS = {
       :allow_nil                   => false,
+      :allow_blank                 => false,
       :ascii_approximation_options => [],
       :max_length                  => 255,
       :reserved_words              => ["index", "new"],
@@ -33,8 +34,9 @@ module FriendlyId
     # Whether to allow friendly_id and/or slugs to be nil. This is not
     # generally useful on its own, but may allow you greater flexibility to
     # customize your application.
-    attr_accessor :allow_nil
+    attr_accessor :allow_nil, :allow_blank
     alias :allow_nil? :allow_nil
+    alias :allow_blank? :allow_blank
 
     # Strip diacritics from Western characters.
     attr_accessor :approximate_ascii

--- a/lib/friendly_id/slugged.rb
+++ b/lib/friendly_id/slugged.rb
@@ -80,7 +80,7 @@ module FriendlyId
       # Get the processed string used as the basis of the friendly id.
       def slug_text
         base = send(friendly_id_config.method)
-        unless base.nil? && friendly_id_config.allow_nil?
+        unless (base.nil? && friendly_id_config.allow_nil?) || (base.blank? && friendly_id_config.allow_blank?)
           text = normalize_friendly_id(SlugString.new(base))
           SlugString.new(text.to_s).validate_for!(friendly_id_config).to_s
         end
@@ -94,7 +94,7 @@ module FriendlyId
       # Has the basis of our friendly id changed, requiring the generation of a
       # new slug?
       def new_slug_needed?
-        if friendly_id_config.allow_nil?
+        if friendly_id_config.allow_nil? || friendly_id_config.allow_blank?
           (!slug? && !slug_text.blank?) || (slug? && slug_text_changed?)
         else
           !slug? || slug_text_changed?

--- a/lib/friendly_id/test.rb
+++ b/lib/friendly_id/test.rb
@@ -112,7 +112,7 @@ module FriendlyId
         end
       end
 
-      test "creation should raise an error if the friendly_id text is nil and allow_nil is false" do
+      test "creation should raise an error if the friendly_id text is nil and allow_nil and/or allow_blank is false" do
         assert_validation_error do
           klass.send(create_method, :name => nil)
         end
@@ -121,6 +121,11 @@ module FriendlyId
       test "creation should succeed if the friendly_id text is nil and allow_nil is true" do
         klass.friendly_id_config.stubs(:allow_nil?).returns(true)
         assert klass.send(create_method, :name => nil)
+      end
+      
+      test "creation should succeed if the friendly_id text is blank and allow_blank is true" do
+        klass.friendly_id_config.stubs(:allow_blank?).returns(true)
+        assert klass.send(create_method, :name => '')
       end
 
       test "should allow the same friendly_id across models" do
@@ -151,6 +156,14 @@ module FriendlyId
         instance = klass.send(create_method, :name => "hello")
         assert instance.friendly_id
         instance.name = nil
+        assert instance.send(save_method)
+      end
+      
+      test "should allow friendly_id to be blankable if allow_blank is true" do
+        klass.friendly_id_config.stubs(:allow_blank?).returns(true)
+        instance = klass.send(create_method, :name => "hello")
+        assert instance.friendly_id
+        instance.name = ''
         assert instance.send(save_method)
       end
 
@@ -221,9 +234,15 @@ module FriendlyId
         assert_equal instance, klass.send(find_method, old_friendly_id)
       end
 
-      test "should not create a slug when allow_nil is true and friendy_id text is blank" do
+      test "should not create a slug when allow_nil is true and friendy_id text is nil" do
         klass.friendly_id_config.stubs(:allow_nil?).returns(true)
         instance = klass.send(create_method, :name => nil)
+        assert_nil instance.slug
+      end
+      
+      test "should not create a slug when allow_blank is true and friendy_id text is blank" do
+        klass.friendly_id_config.stubs(:allow_blank?).returns(true)
+        instance = klass.send(create_method, :name => '')
         assert_nil instance.slug
       end
 
@@ -232,6 +251,16 @@ module FriendlyId
         instance = klass.send(create_method, :name => "hello")
         assert instance.friendly_id
         instance.name = nil
+        assert_validation_error do
+          instance.send(save_method)
+        end
+      end
+
+      test "should not allow friendly_id to be blank even if allow_blank is true" do
+        klass.friendly_id_config.stubs(:allow_blank?).returns(true)
+        instance = klass.send(create_method, :name => "hello")
+        assert instance.friendly_id
+        instance.name = ''
         assert_validation_error do
           instance.send(save_method)
         end


### PR DESCRIPTION
When using forms to post data most of the time the value of an attribute will be "" (blank string) rather than nil, so to allow friendly_id to work with blank fields being posted from forms I added allow_blank, mimicking the syntax from Rails validations.
