### PR TITLE
Ability to use non-numeric primary key

### DIFF
--- a/lib/friendly_id/active_record_adapter/finders.rb
+++ b/lib/friendly_id/active_record_adapter/finders.rb
@@ -63,7 +63,7 @@ module FriendlyId
         def parse_ids!
           @id = id.uniq.map do |member|
             if member.respond_to?(:friendly_id_config)
-              member.id.to_i
+              member.id
             else
               member
             end

--- a/lib/friendly_id/active_record_adapter/relation.rb
+++ b/lib/friendly_id/active_record_adapter/relation.rb
@@ -29,7 +29,7 @@ module FriendlyId
         end
 
         def find_some
-          ids = @ids.compact.uniq.map {|id| id.respond_to?(:friendly_id_config) ? id.id.to_i : id}
+          ids = @ids.compact.uniq.map {|id| id.respond_to?(:friendly_id_config) ? id.id : id}
           friendly_ids, unfriendly_ids = ids.partition {|id| id.friendly_id?}
           return if friendly_ids.empty?
           records = friendly_records(friendly_ids, unfriendly_ids).each do |record|
@@ -156,7 +156,7 @@ module FriendlyId
         Find.new(self, ids).find_some or begin
           # A change in Arel 2.0.x causes find_some to fail with arrays of instances; not sure why.
           # This is an emergency, temporary fix.
-          ids = ids.map {|id| (id.respond_to?(:friendly_id_config) ? id.id : id).to_i}
+          ids = ids.map {|id| (id.respond_to?(:friendly_id_config) ? id.id : id)}
           super
         end
       end

--- a/lib/friendly_id/active_record_adapter/slug.rb
+++ b/lib/friendly_id/active_record_adapter/slug.rb
@@ -19,7 +19,7 @@ class Slug < ::ActiveRecord::Base
     sluggable_id && !@sluggable and begin
       klass = sluggable_type.constantize
       klass.send(:with_exclusive_scope) do
-        @sluggable = klass.find(sluggable_id.to_i)
+        @sluggable = klass.find(sluggable_id)
       end
     end
     @sluggable


### PR DESCRIPTION
I removed some 'to_i' on id attribute that were preventing a non numeric primary key to work with friendly_id.
rake test:friendly_id still passes so I think I didn’t break anything ;)
