### PR TITLE
fixed rake tasks for 2.3.x

### DIFF
--- a/lib/friendly_id/active_record_adapter/tasks.rb
+++ b/lib/friendly_id/active_record_adapter/tasks.rb
@@ -36,7 +36,7 @@ module FriendlyId
       while records = find(:all, options) do
         break if records.size == 0
         records.each do |record|
-          record.save(:validate => false) unless record.slug?
+          record.save(Rails.version > "2.3.11" ? {:validate => false} : false) unless record.slug?
           yield(record) if block_given?
         end
         options[:offset] += options[:limit]


### PR DESCRIPTION
save(:validate => false) to save(Rails.version > "2.3.11" ? {:validate => false} : false)
