### PR TITLE
Test against mysql2, bump latest Rails testing to 3.1.0.rc5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ end
 
 platform :ruby do
   gem "mysql"
+  gem "mysql2", ENV["DB_VERSION"] || "~> 0.2.11"
   gem "pg"
   gem "sqlite3"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,7 @@ def rubies(&block)
 end
 
 def versions(&block)
-  ["3.1.0.rc4", "3.0.9"].each do |version|
+  ["3.1.0.rc5", "3.0.9"].each do |version|
     old = ENV["AR"]
     ENV["AR"] = version
     yield
@@ -20,9 +20,10 @@ def versions(&block)
 end
 
 def adapters(&block)
-  ["mysql", "postgres", "sqlite3"].each do |adapter|
+  ["mysql", "mysql2", "postgres", "sqlite3"].each do |adapter|
     old = ENV["DB"]
     ENV["DB"] = adapter
+    ENV["DB_VERSION"] = "~> 0.3.6" if adapter == "mysql2" && ENV["AR"] && ENV["AR"][0..2] >= "3.1"
     yield
     ENV["DB"] = old
   end

--- a/lib/friendly_id/history.rb
+++ b/lib/friendly_id/history.rb
@@ -10,7 +10,7 @@ module FriendlyId
         has_many :friendly_id_slugs, :as => :sluggable, :dependent => :destroy
         before_save :build_friendly_id_slug, :if => lambda {|r| r.slug_sequencer.slug_changed?}
         scope :with_friendly_id, lambda {|id| includes(:friendly_id_slugs).where("friendly_id_slugs.slug = ?", id)}
-        extend  Finder
+        extend Finder
       end
     end
 

--- a/test/config/mysql2.yml
+++ b/test/config/mysql2.yml
@@ -1,0 +1,5 @@
+adapter: mysql2
+database: friendly_id_test
+username: root
+hostname: localhost
+encoding: utf8


### PR DESCRIPTION
Since Rails 3 uses mysql2 as the default adapter for MySQL, figured we should be testing against it.
