### PR TITLE
Fixed link to "What's New" doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ FriendlyId is compatible with Active Record **3.0** and **3.1**.
 
 FriendlyId 4.x introduces many changes incompatible with 3.x. If you're
 upgrading, please [read the
-docs](http://norman.github.com/friendly_id/file.WhatsNew.html) to see what's
+docs](https://github.com/norman/friendly_id/blob/master/WhatsNew.md) to see what's
 new.
 
 ## Docs


### PR DESCRIPTION
The link to the "What's New" doc didn't work.
