### PR TITLE
"RuntimeError: can't modify frozen hash" when destroying a model in Rails 3.1

### DIFF
--- a/lib/friendly_id/active_record_adapter/slugged_model.rb
+++ b/lib/friendly_id/active_record_adapter/slugged_model.rb
@@ -4,8 +4,8 @@ module FriendlyId
 
       def self.included(base)
         base.class_eval do
-          has_many :slugs, :order => 'id DESC', :as => :sluggable, :dependent => :destroy
           has_one :slug, :order => 'id DESC', :as => :sluggable, :dependent => :nullify
+          has_many :slugs, :order => 'id DESC', :as => :sluggable, :dependent => :destroy
           before_save :build_a_slug
           after_save :set_slug_cache
           after_update :update_scope


### PR DESCRIPTION
I've been getting the following error when running tests that destroy a record which uses FriendlyId. The app is Rails 3.1 and using FriendlyId 3.3.0.1:

```
RuntimeError: can't modify frozen hash
    /Users/theozaurus/.rvm/gems/ruby-1.9.2-p290/gems/activerecord-3.1.0/lib/active_record/attribute_methods/write.rb:30:in `[]='
    /Users/theozaurus/.rvm/gems/ruby-1.9.2-p290/gems/activerecord-3.1.0/lib/active_record/attribute_methods/write.rb:30:in `write_attribute'
    /Users/theozaurus/.rvm/gems/ruby-1.9.2-p290/gems/activerecord-3.1.0/lib/active_record/attribute_methods/dirty.rb:67:in `write_attribute'
    /Users/theozaurus/.rvm/gems/ruby-1.9.2-p290/gems/activerecord-3.1.0/lib/active_record/attribute_methods/write.rb:14:in `sluggable_id='
    /Users/theozaurus/.rvm/gems/ruby-1.9.2-p290/gems/activerecord-3.1.0/lib/active_record/persistence.rb:132:in `update_attribute'
    /Users/theozaurus/.rvm/gems/ruby-1.9.2-p290/gems/activerecord-3.1.0/lib/active_record/associations/has_one_association.rb:39:in `delete'
    /Users/theozaurus/.rvm/gems/ruby-1.9.2-p290/gems/activerecord-3.1.0/lib/active_record/associations/builder/has_one.rb:49:in `has_one_dependent_nullify_for_slug'
    /Users/theozaurus/.rvm/gems/ruby-1.9.2-p290/gems/activesupport-3.1.0/lib/active_support/callbacks.rb:404:in `_run_destroy_callbacks'
    /Users/theozaurus/.rvm/gems/ruby-1.9.2-p290/gems/paranoid_create-0.1.0/lib/paranoid/paranoid_methods.rb:61:in `destroy'
    test/unit/question_test.rb:233:in `block (3 levels) in <class:QuestionTest>'
    /Users/theozaurus/.rvm/gems/ruby-1.9.2-p290/gems/shoulda-2.11.3/lib/shoulda/context.rb:382:in `call'
    /Users/theozaurus/.rvm/gems/ruby-1.9.2-p290/gems/shoulda-2.11.3/lib/shoulda/context.rb:382:in `block in create_test_from_should_hash'
    /Users/theozaurus/.rvm/gems/ruby-1.9.2-p290/gems/mocha-0.9.8/lib/mocha/integration/mini_test/version_131_and_above.rb:26:in `run'
    /Users/theozaurus/.rvm/gems/ruby-1.9.2-p290/gems/activesupport-3.1.0/lib/active_support/testing/setup_and_teardown.rb:35:in `block in run'
    /Users/theozaurus/.rvm/gems/ruby-1.9.2-p290/gems/activesupport-3.1.0/lib/active_support/callbacks.rb:408:in `_run_setup_callbacks'
    /Users/theozaurus/.rvm/gems/ruby-1.9.2-p290/gems/activesupport-3.1.0/lib/active_support/callbacks.rb:81:in `run_callbacks'
    /Users/theozaurus/.rvm/gems/ruby-1.9.2-p290/gems/activesupport-3.1.0/lib/active_support/testing/setup_and_teardown.rb:34:in `run'
```

I've been able to correct this by altering the order of the `has_one` and `has_many` statements in `SluggedModel`.

I'm not certain, but I imagine a better fix would be to remove the `:dependent => :nullify` on the `has_one` and let the has_many clean up any old records. However, I may be misunderstanding the intention of the code.
