### PR TITLE
Do not create a new configuration anonymous class if @friendly_id_config 

### DIFF
--- a/lib/friendly_id.rb
+++ b/lib/friendly_id.rb
@@ -119,7 +119,7 @@ module FriendlyId
     end
     model_class.instance_eval do
       extend Base
-      @friendly_id_config = Class.new(Configuration).new(self)
+      @friendly_id_config ||= Class.new(Configuration).new(self)
       FriendlyId.defaults.call @friendly_id_config
     end
   end


### PR DESCRIPTION
When used with Spork and Rspec, it returns the following error for every object with FriendlyId included: "undefined method `slug_generator_class' for #<#Class:0x007fe6dbf18618:0x007fe6dbf18578>". Still have to investigate what's happening but here is the quick fix.
