### PR TITLE
Saving should not change slug when sluggable field doesn't change.

### DIFF
--- a/lib/friendly_id/slugged.rb
+++ b/lib/friendly_id/slugged.rb
@@ -196,7 +196,7 @@ This functionality was in fact taken from earlier versions of FriendlyId.
     # slugs to be generated once, and then never updated.
     def should_generate_new_friendly_id?
       return true if new_record?
-      slug_base = send friendly_id_config.base
+      slug_base = normalize_friendly_id send(friendly_id_config.base)
       separator = Regexp.escape friendly_id_config.sequence_separator
       slug_base != current_friendly_id.try(:sub, /#{separator}[\d]*\z/, '')
     end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -39,7 +39,7 @@ module FriendlyId
 
     def with_instance_of(*args)
       model_class = args.shift
-      args[0] ||= {:name => "a"}
+      args[0] ||= {:name => "a b c"}
       transaction { yield model_class.create!(*args) }
     end
 


### PR DESCRIPTION
Saving a record that has a duplicate slug sometimes changes its slug.

``` ruby
r1 = Record.create :name => "Foo Bar"
r2 = Record.create :name => "Foo Bar"

r1.slug # "foo-bar"

r1.save

r1.slug # "foo-bar--3"
```

This only occurs when the sluggable field contains text that doesn't exactly match the slug (i.e., "A B C" doesn't match "a-b-c") 

Note that there are still failing tests in this pull request. We weren't able to figure out how to fix the I18n code to work with our fix.
