### PR TITLE
Use `find_each` instead of `all` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The current docs can always be found
     # If you're adding FriendlyId to an existing app and need
     # to generate slugs for existing users, do this from the
     # console, runner, or add a Rake task:
-    User.all.map(&:save)
+    User.find_each(&:save)
 
 
 ## Benchmarks


### PR DESCRIPTION
There might be a lot of users and you do not want to load them all into memory. `find_each` loads them in batches of 1000.
