### PR TITLE
Fixing "Duplicate entry on slug" when using Single Table Inheritance

### DIFF
--- a/lib/friendly_id/slug_generator.rb
+++ b/lib/friendly_id/slug_generator.rb
@@ -60,17 +60,7 @@ module FriendlyId
     end
 
     def sluggable_class
-      return @sluggable_class if defined? @sluggable_class
-
-      if sluggable.class.superclass == ActiveRecord::Base
-        @sluggable_class = sluggable.class
-      else
-        begin
-          @sluggable_class = sluggable.class.superclass
-        end while @sluggable_class.superclass != ActiveRecord::Base
-      end
-
-      @sluggable_class
+      @sluggable_class ||= sluggable.class.table_name.capitalize.singularize.constantize
     end
   end
 end


### PR DESCRIPTION
Hey everyone,

i ran into an issue with the newest version (4.0.0 Beta) of Friendly ID when using Single Table Inheritance.

The problem is that the slug generator is looking for an existing slug by accessing the table via `sluggable.class`. If sluggable is a STI model you're only accessing the instances of this concrete subclass and not all possible instances. Doing it this way you do not recognize a duplicate slug entry, the generator is not notifying any conflicts, no sequence will be created and SQL finally throws an exception (if you defined an unique index on the column).

I hereby submit a quick solution for the problem. This works (to my knowledge) in the regular case, STI case and even Multiple Table Inheritance case.

I'd appreciate the acceptance of the pull request. If you do know any easier solution I'd be happy to hear it :)

Best regards

P.S.: The first commits were a quick and dirty fix for a live system. Do not judge me by this attempt ;)
