### PR TITLE
Minor alteration to sequence extraction in slug_generator.rb

### DIFF
--- a/lib/friendly_id/slug_generator.rb
+++ b/lib/friendly_id/slug_generator.rb
@@ -12,7 +12,8 @@ module FriendlyId
 
     # Given a slug, get the next available slug in the sequence.
     def next
-      sequence = conflict.to_param.split(separator)[1].to_i
+      # Don't assume that the separator is unique within the slug
+      sequence = conflict.to_param.gsub(/^#{Regexp.quote(normalized)}(#{Regexp.quote(separator)})?/, '').to_i
       next_sequence = sequence == 0 ? 2 : sequence.next
       "#{normalized}#{separator}#{next_sequence}"
     end


### PR DESCRIPTION
This came about because we'd like to use a single hyphen as the sequence separator. The current implementation assumes the separator is unique and safe to just split on it.

My first inclination was to simply change the array index on the split to -1. That would work MOST of the time, except when the last word of a non-sequenced slug happens to start with a number. (A year, for example)

This solution better covers all cases, and possibly more straightforward as well.

All of the tests pass, I debated adding a new one to cover this case, and would be happy to do so if you'd prefer.
