### PR TITLE
3.x specificity fix

### DIFF
--- a/friendly_id.gemspec
+++ b/friendly_id.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.version           = FriendlyId::Version::STRING
 
   s.add_dependency "babosa", "~> 0.3.0"
-  s.add_development_dependency "activerecord", "< 3.2"
+  s.add_development_dependency "activerecord", ">= 3.0", "< 3.2"
   s.add_development_dependency "mocha", "~> 0.9"
   s.add_development_dependency "sqlite3", "~> 1.3"
   s.add_development_dependency "rake", "~> 0.9.2"


### PR DESCRIPTION
Just specifying < 3.2 will allow people to use Rails 2.x again!
