### PR TITLE
Added support for multiple scopes

### DIFF
--- a/test/schema.rb
+++ b/test/schema.rb
@@ -30,6 +30,7 @@ module FriendlyId
 
           # This will be used to test scopes
           add_column :novels, :novelist_id, :integer
+          add_column :novels, :publisher_id, :integer
           remove_index :novels, :slug
 
           # This will be used to test column name quoting
@@ -53,7 +54,7 @@ module FriendlyId
         end
 
         def simple_tables
-          ["authors", "books"]
+          ["authors", "books", "publishers"]
         end
 
         def tables

--- a/test/scoped_test.rb
+++ b/test/scoped_test.rb
@@ -8,7 +8,12 @@ end
 class Novel < ActiveRecord::Base
   extend FriendlyId
   belongs_to :novelist
-  friendly_id :name, :use => :scoped, :scope => :novelist
+  belongs_to :publisher
+  friendly_id :name, :use => :scoped, :scope => [:publisher, :novelist]
+end
+
+class Publisher < ActiveRecord::Base
+  has_many :novels
 end
 
 class ScopedTest < MiniTest::Unit::TestCase
@@ -21,14 +26,14 @@ class ScopedTest < MiniTest::Unit::TestCase
   end
 
   test "should detect scope column from belongs_to relation" do
-    assert_equal "novelist_id", Novel.friendly_id_config.scope_column
+    assert_equal ["publisher_id", "novelist_id"], Novel.friendly_id_config.scope_columns
   end
 
   test "should detect scope column from explicit column name" do
     model_class = Class.new(ActiveRecord::Base)
     model_class.extend FriendlyId
     model_class.friendly_id :empty, :use => :scoped, :scope => :dummy
-    assert_equal "dummy", model_class.friendly_id_config.scope_column
+    assert_equal ["dummy"], model_class.friendly_id_config.scope_columns
   end
 
   test "should allow duplicate slugs outside scope" do
@@ -52,6 +57,22 @@ class ScopedTest < MiniTest::Unit::TestCase
     model_class.extend FriendlyId
     assert_raises RuntimeError do
       model_class.friendly_id :name, :use => [:scoped, :history]
+    end
+  end
+
+  test "should apply scope with multiple columns" do
+    transaction do
+      novelist = Novelist.create! :name => "a"
+      publisher = Publisher.create! :name => "b"
+
+      novel1 = Novel.create! :name => "c", :novelist => novelist, :publisher => publisher
+      novel2 = Novel.create! :name => "c", :novelist => novelist, :publisher => Publisher.create(:name => "d")
+      novel3 = Novel.create! :name => "c", :novelist => Novelist.create(:name => "e"), :publisher => publisher
+      novel4 = Novel.create! :name => "c", :novelist => novelist, :publisher => publisher
+
+      assert_equal novel1.friendly_id, novel2.friendly_id
+      assert_equal novel2.friendly_id, novel3.friendly_id
+      assert novel3.friendly_id != novel4.friendly_id
     end
   end
 end


### PR DESCRIPTION
Fixes #165 by optionally accepting an array of columns/associations for the `:scope` option when generating scoped slugs.

Example:

```
friendly_id :title, :use => :scoped, :scope => [:publisher, :source]
```
