### PR TITLE
Historic slug conflicts

### DIFF
--- a/test/history_test.rb
+++ b/test/history_test.rb
@@ -89,12 +89,13 @@ class HistoryTest < MiniTest::Unit::TestCase
   end
 
   test "should not create new slugs that match old slugs" do
-    transaction do 
+    transaction do
       first_record = model_class.create! :name => "foo"
       first_record.name = "bar"
       first_record.save!
       second_record = model_class.create! :name => "foo"
       assert second_record.slug != "foo"
+      assert second_record.slug == "foo--2"
     end
   end
 


### PR DESCRIPTION
We added a fix for the failing test submitted by @earnold. It patches the history plugin by adding custom SlugGenerator overrides. When querying for slug conflicts, it checks the Slug model instead of the sluggable model.

And here's a picture of an adorable baby polar bear:
![Knut the cute polar bear](http://upload.wikimedia.org/wikipedia/commons/8/80/Knut_IMG_8095.jpg)
