### PR TITLE
Related to Issue #200, slight code clean-up.

### DIFF
--- a/lib/friendly_id/slug_generator.rb
+++ b/lib/friendly_id/slug_generator.rb
@@ -12,10 +12,7 @@ module FriendlyId
 
     # Given a slug, get the next available slug in the sequence.
     def next
-      # Don't assume that the separator is unique within the slug
-      sequence = conflict.to_param.gsub(/^#{Regexp.quote(normalized)}(#{Regexp.quote(separator)})?/, '').to_i
-      next_sequence = sequence == 0 ? 2 : sequence.next
-      "#{normalized}#{separator}#{next_sequence}"
+      "#{normalized}#{separator}#{next_in_sequence}"
     end
 
     # Generate a new sequenced slug.
@@ -24,6 +21,15 @@ module FriendlyId
     end
 
     private
+
+    def next_in_sequence
+      last_in_sequence == 0 ? 2 : last_in_sequence.next
+    end
+
+    def last_in_sequence
+      # Don't assume that the separator is unique in the slug.
+      @_last_in_sequence ||= conflict.to_param.gsub(/^#{Regexp.quote(normalized)}(#{Regexp.quote(separator)})?/, '').to_i
+    end
 
     def column
       sluggable.connection.quote_column_name friendly_id_config.slug_column


### PR DESCRIPTION
This is a trivial pull request, it (naturally) still passes all tests, but is intended to allow me to more easily extend the SlugGenerator class, and borrow the behaviour which helps me writing my own implementation (`#wildcard`, `#column`, `#separator`, etc) whilst extending the parts which might need to be modified.

I'm planning to take the short route, to implementing my own Redis backed option, and would like to see this come upstream so that I might determine the best places to hook/override behaviour.
