### PR TITLE
When checking for conflicts using the history module, we should build the list of conflicting slugs from the history

### DIFF
--- a/lib/friendly_id/slug_generator.rb
+++ b/lib/friendly_id/slug_generator.rb
@@ -27,8 +27,12 @@ module FriendlyId
     end
 
     def last_in_sequence
+      @_last_in_sequence ||= extract_sequence_from_slug(conflict.to_param)
+    end
+
+    def extract_sequence_from_slug(slug)
       # Don't assume that the separator is unique in the slug.
-      @_last_in_sequence ||= conflict.to_param.gsub(/^#{Regexp.quote(normalized)}(#{Regexp.quote(separator)})?/, '').to_i
+      slug.gsub(/^#{Regexp.quote(normalized)}(#{Regexp.quote(separator)})?/, '').to_i
     end
 
     def column

--- a/test/history_test.rb
+++ b/test/history_test.rb
@@ -68,6 +68,16 @@ class HistoryTest < MiniTest::Unit::TestCase
     end
   end
 
+  test "should create correct sequence numbers even when some conflicted slugs have changed" do
+    transaction do
+      record1 = model_class.create! :name => 'hello'
+      record2 = model_class.create! :name => 'hello!'
+      record2.update_attributes :name => 'goodbye'
+      record3 = model_class.create! :name => 'hello!'
+      assert_equal 'hello--3', record3.slug
+    end
+  end
+
 
   test "should raise error if used with scoped" do
     model_class = Class.new(ActiveRecord::Base) do


### PR DESCRIPTION
…not the current values for those models, which may have changed.

NOTE: Rather than the changes to last_in_sequence, it’s possible to just change the FriendlyId::Slug#to_param to return the slug rather than the id. But we didn’t want to change the public API for that model.

Addresses Issue #230.
