### PR TITLE
3.x

### DIFF
--- a/lib/friendly_id/active_record_adapter/slugged_model.rb
+++ b/lib/friendly_id/active_record_adapter/slugged_model.rb
@@ -80,7 +80,7 @@ module FriendlyId
           slug.scope = send(friendly_id_config.scope).to_param
           similar = Slug.similar_to(slug)
           if !similar.empty?
-            slug.sequence = similar.first.sequence.succ
+            slug.sequence = similar.last.sequence.succ
           end
           slug.save!
         end

--- a/test/active_record_adapter/scoped_model_test.rb
+++ b/test/active_record_adapter/scoped_model_test.rb
@@ -64,6 +64,15 @@ module FriendlyId
         assert_equal "canada", @resident.slugs(true).first.scope
       end
 
+      test "updating the scope should increment sequence correctly when there's more than one
+            existing slug in scope" do
+        resident4 = Resident.create!(:name => "John Smith", :country => @canada)
+        old_friendly_id = @resident.friendly_id
+        @resident.update_attributes! :country => @canada
+        assert_equal "#{old_friendly_id}--3", @resident.friendly_id
+        assert_equal "canada", @resident.slugs(true).first.scope
+      end
+
       test "a non-slugged model should update its child model's scopes when its friendly_id changes" do
         @user.update_attributes(:name => "jack")
         assert_equal "jack", @user.to_param


### PR DESCRIPTION
Hi, 

Hope you're still interested in patches to the 3.x branch - I think this fixes an issue when updating the scope of a slug:

A slug that gets a scope which already has slugs with the same name should be the next integer after the sequence of the last similar slug, not the first.

Thanks for such a great gem!

Louise
