### PR TITLE
locale instead of current_locale for SimpleI18n.set_friendly_id

### DIFF
--- a/lib/friendly_id/simple_i18n.rb
+++ b/lib/friendly_id/simple_i18n.rb
@@ -80,7 +80,7 @@ current locale:
 
     module Model
       def set_friendly_id(text, locale = nil)
-        I18n.with_locale(locale || I18n.current_locale) do
+        I18n.with_locale(locale || I18n.locale) do
           set_slug(normalize_friendly_id(text))
         end
       end


### PR DESCRIPTION
Hi Norman,

Thanks for the great gem! I was trying to run the set_friendly_id method but it didn't find the I18n.current_locale, I assume this may be for an older version of I18n? In any case I'm sending a pull request if it is right. It worked for me... Best,
