### PR TITLE
Move_friendly_id_error_to_name example method removes errors on name field

### DIFF
--- a/lib/friendly_id/reserved.rb
+++ b/lib/friendly_id/reserved.rb
@@ -30,7 +30,7 @@ For example:
     after_validation :move_friendly_id_error_to_name
 
     def move_friendly_id_error_to_name
-      errors.messages[:name] = errors.messages.delete(:friendly_id)
+      errors.messages[:name] = errors.messages.delete(:friendly_id) if errors[:friendly_id].present?
     end
   end
 


### PR DESCRIPTION
If there is no error in friendly_id attribute then #move_friendly_id_error_to_name removes any existing error from the name attribute.
