### PR TITLE
Allow to try different slugging approaches in conflicts

### DIFF
--- a/lib/friendly_id/globalize.rb
+++ b/lib/friendly_id/globalize.rb
@@ -68,7 +68,7 @@ assign a value to the +slug+ field:
 
     module Model
       def slug=(text)
-        set_slug(normalize_friendly_id(text))
+        set_slug(text)
       end
     end
 

--- a/lib/friendly_id/history.rb
+++ b/lib/friendly_id/history.rb
@@ -126,7 +126,7 @@ method.
         pkey            = sluggable_class.primary_key
         value           = sluggable.send pkey
 
-        scope = Slug.where("slug = ? OR slug LIKE ?", normalized, wildcard)
+        scope = Slug.where("slug = ? OR slug LIKE ?", @normalized_cantidate, wildcard)
         scope = scope.where(:sluggable_type => sluggable_class.to_s)
         scope = scope.where("sluggable_id <> ?", value) unless sluggable.new_record?
         scope.order("LENGTH(slug) DESC, slug DESC")

--- a/lib/friendly_id/simple_i18n.rb
+++ b/lib/friendly_id/simple_i18n.rb
@@ -81,7 +81,7 @@ current locale:
     module Model
       def set_friendly_id(text, locale = nil)
         I18n.with_locale(locale || I18n.current_locale) do
-          set_slug(normalize_friendly_id(text))
+          set_slug(text)
         end
       end
     end

--- a/test/slugged_test.rb
+++ b/test/slugged_test.rb
@@ -133,20 +133,14 @@ class SlugGeneratorTest < MiniTest::Unit::TestCase
     model_class = Class.new(ActiveRecord::Base) do
       self.table_name = "articles"
       extend FriendlyId
-      friendly_id :name, :use => :slugged
+      friendly_id [:name, :attempt1, lambda{"#{name} attempt 2"}], :use => :slugged
+
       def self.name
         "Article"
       end
 
-      def resolve_slug_conflict(attempts)
-        case attempts
-          when 1
-            "#{name} attempt 1"
-          when 2
-            "#{name} attempt 2"
-          else
-            super
-        end
+      def attempt1
+        "#{self.name} attempt 1"
       end
     end
     transaction do


### PR DESCRIPTION
This adds the overridable method `resolve_slug_conflict`, which will be called when there is a slug conflict before adding a sequence number.

It allows to try different names for the slug before relying on the sequence.

 For example, you might want to add a country to the slug only if there is a conflict. If this still fails, you might want to add a city. If that fails then a sequence number will be appended on top of the last attempt.

Usage:

``` ruby
class Person < ActiveRecord::Base
  friendly_id :name

  def resolve_slug_conflict(attempts)
    case attempts
      when 1
        "#{name} from #{location}"
      when 2
        "#{name} from #{city} in #{location}"
      else
        super
    end
  end
end

bob1 = Person.create! :name => "Bob Smith", :country => "USA", :city => "New York City"
bob2 = Person.create! :name => "Bob Smith", :country => "USA", :city => "New York City"
bob3 = Person.create! :name => "Bob Smith", :country => "USA", :city => "New York City"
bob4 = Person.create! :name => "Bob Smith", :country => "USA", :city => "New York City"
bob1.friendly_id #=> "bob-smith"
bob2.friendly_id #=> "bob-smith-from-usa"
bob3.friendly_id #=> "bob-smith-from-new-york-city-in-usa"
bob4.friendly_id #=> "bob-smith-from-new-york-city-in-usa--2"
```
