### PR TITLE
Delegate to_param to super when friendly_id is not present.

### DIFF
--- a/lib/friendly_id/base.rb
+++ b/lib/friendly_id/base.rb
@@ -268,7 +268,7 @@ often better and easier to use {FriendlyId::Slugged slugs}.
       if diff = changes[friendly_id_config.query_field]
         diff.first || diff.second
       else
-        friendly_id.present? ? friendly_id : id.to_s
+        friendly_id.presence || super
       end
     end
   end

--- a/test/shared.rb
+++ b/test/shared.rb
@@ -145,6 +145,10 @@ module FriendlyId
             assert_equal record.id.to_s, record.to_param
           end
         end
+
+        test "should return nil for to_param with a new record" do
+          assert_equal nil, model_class.new.to_param
+        end
       end
     end
   end


### PR DESCRIPTION
Currently ActiveRecord::Base#to_param returns nil when the record
is not persisted. Rather than calling to_s on id, call super instead 
so that we get the default behavior.

Closes #294.
