### PR TITLE
make :scoped and :history modules compatible with each other

### DIFF
--- a/Guide.rdoc
+++ b/Guide.rdoc
@@ -296,8 +296,6 @@ model.
 
 === Considerations
 
-This module is incompatible with the +:scoped+ module.
-
 Because recording slug history requires creating additional database records,
 this module has an impact on the performance of the associated model's +create+
 method.

--- a/lib/friendly_id/configuration.rb
+++ b/lib/friendly_id/configuration.rb
@@ -30,6 +30,9 @@ module FriendlyId
     # The default configuration options.
     attr_reader :defaults
 
+    # The modules in use
+    attr_reader :modules
+
     # The model class that this configuration belongs to.
     # @return ActiveRecord::Base
     attr_accessor :model_class
@@ -37,6 +40,7 @@ module FriendlyId
     def initialize(model_class, values = nil)
       @model_class = model_class
       @defaults    = {}
+      @modules     = []
       set values
     end
 
@@ -59,7 +63,13 @@ module FriendlyId
       modules.to_a.flatten.compact.map do |object|
         mod = object.kind_of?(Module) ? object : FriendlyId.const_get(object.to_s.classify)
         model_class.send(:include, mod)
+        @modules << mod.name.split("::").last.downcase.to_sym if mod.name.present?
       end
+    end
+
+    # Returns whether the given module is in use
+    def uses?(modul)
+      @modules.include?(modul)
     end
 
     # The column that FriendlyId will use to find the record when querying by

--- a/lib/friendly_id/migration.rb
+++ b/lib/friendly_id/migration.rb
@@ -5,10 +5,12 @@ class CreateFriendlyIdSlugs < ActiveRecord::Migration
       t.string   :slug,           :null => false
       t.integer  :sluggable_id,   :null => false
       t.string   :sluggable_type, :limit => 40
+      t.string   :scope
       t.datetime :created_at
     end
     add_index :friendly_id_slugs, :sluggable_id
-    add_index :friendly_id_slugs, [:slug, :sluggable_type], :unique => true
+    add_index :friendly_id_slugs, [:slug, :sluggable_type]
+    add_index :friendly_id_slugs, [:slug, :sluggable_type, :scope], :unique => true
     add_index :friendly_id_slugs, :sluggable_type
   end
 

--- a/lib/friendly_id/scoped.rb
+++ b/lib/friendly_id/scoped.rb
@@ -86,11 +86,14 @@ an example of one way to set this up:
     # feature.
     def self.included(model_class)
       model_class.instance_eval do
-        raise "FriendlyId::Scoped is incompatibe with FriendlyId::History" if self < History
         include Slugged unless self < Slugged
         friendly_id_config.class.send :include, Configuration
         friendly_id_config.slug_generator_class.send :include, SlugGenerator
       end
+    end
+
+    def serialized_scope
+      friendly_id_config.scope_columns.sort.map { |column| "#{column}:#{send(column)}" }.join(",")
     end
 
     # This module adds the +:scope+ configuration option to
@@ -137,12 +140,18 @@ an example of one way to set this up:
       private
 
       def conflict
-        columns = friendly_id_config.scope_columns
-        matched = columns.inject(conflicts) do |memo, column|
-           memo.where(column => sluggable.send(column))
-        end
+        if friendly_id_config.uses?(:history)
+          # When using the :history module +conflicts+ already returns only real conflicts, so there's no need to check
+          # for the scope columns again
+          conflicts.first
+        else
+          columns = friendly_id_config.scope_columns
+          matched = columns.inject(conflicts) do |memo, column|
+            memo.where(column => sluggable.send(column))
+          end
 
-        matched.first
+          matched.first
+        end
       end
     end
   end

--- a/test/history_test.rb
+++ b/test/history_test.rb
@@ -78,17 +78,6 @@ class HistoryTest < MiniTest::Unit::TestCase
     end
   end
 
-
-  test "should raise error if used with scoped" do
-    model_class = Class.new(ActiveRecord::Base) do
-      self.abstract_class = true
-      extend FriendlyId
-    end
-    assert_raises RuntimeError do
-      model_class.friendly_id :name, :use => [:history, :scoped]
-    end
-  end
-
   test "should handle renames" do
     with_instance_of(model_class) do |record|
       record.name = 'x'
@@ -145,5 +134,69 @@ class HistoryTestWithSti < HistoryTest
 
   def model_class
     Editorialist
+  end
+end
+
+
+
+class City < ActiveRecord::Base
+  has_many :restaurants
+end
+
+class Restaurant < ActiveRecord::Base
+  extend FriendlyId
+  belongs_to :city
+  friendly_id :name, :use => [:history, :scoped], :scope => :city
+end
+
+class ScopedHistoryTest < MiniTest::Unit::TestCase
+  include FriendlyId::Test
+  include FriendlyId::Test::Shared::Core
+
+  def model_class
+    Restaurant
+  end
+
+  test "should find old scoped slugs" do
+    city = City.create!
+    with_instance_of(Restaurant) do |record|
+      record.city = city
+
+      record.name = "x"
+      record.save!
+
+      record.name = "y"
+      record.save!
+
+      assert_equal city.restaurants.find("x"), city.restaurants.find("y")
+    end
+  end
+
+  test "should consider old scoped slugs when creating slugs" do
+    city = City.create!
+    with_instance_of(Restaurant) do |record|
+      record.city = city
+
+      record.name = "x"
+      record.save!
+
+      record.name = "y"
+      record.save!
+
+      second_record = model_class.create! :city => city, :name => 'x'
+      assert_equal "x--2", second_record.friendly_id
+
+      third_record = model_class.create! :city => city, :name => 'y'
+      assert_equal "y--2", third_record.friendly_id
+    end
+  end
+
+  test "should allow equal slugs in different scopes" do
+    city = City.create!
+    second_city = City.create!
+    record = model_class.create! :city => city, :name => 'x'
+    second_record = model_class.create! :city => second_city, :name => 'x'
+
+    assert_equal record.slug, second_record.slug
   end
 end

--- a/test/schema.rb
+++ b/test/schema.rb
@@ -34,6 +34,10 @@ module FriendlyId
             add_index  table_name, :slug, :unique => true
           end
 
+          scoped_tables.each do |table_name|
+            add_column table_name, :slug, :string
+          end
+
           # This will be used to test scopes
           add_column :novels, :novelist_id, :integer
           add_column :novels, :publisher_id, :integer
@@ -57,6 +61,9 @@ module FriendlyId
           # This will be used to test relationships
           add_column :books, :author_id, :integer
 
+          # Used to test :scoped and :history together
+          add_column :restaurants, :city_id, :integer
+
           @done = true
         end
 
@@ -66,12 +73,16 @@ module FriendlyId
           %w[journalists articles novelists novels manuals translated_articles]
         end
 
+        def scoped_tables
+          ["restaurants"]
+        end
+
         def simple_tables
-          %w[authors books publishers]
+          %w[authors books publishers cities]
         end
 
         def tables
-          simple_tables + slugged_tables
+          simple_tables + slugged_tables + scoped_tables
         end
       end
     end

--- a/test/scoped_test.rb
+++ b/test/scoped_test.rb
@@ -54,17 +54,6 @@ class ScopedTest < MiniTest::Unit::TestCase
     end
   end
 
-  test "should raise error if used with history" do
-    model_class = Class.new(ActiveRecord::Base) do
-      self.abstract_class = true
-      extend FriendlyId
-    end
-
-    assert_raises RuntimeError do
-      model_class.friendly_id :name, :use => [:scoped, :history]
-    end
-  end
-
   test "should apply scope with multiple columns" do
     transaction do
       novelist = Novelist.create! :name => "a"


### PR DESCRIPTION
Up to now it wasn't possible to use the :scoped and :history modules together. This is fixed by adding a `serialized_scope` method wich is stored in the slugs table and used for detecting conflicts.

fixes #215
