### PR TITLE
Document necessary location of slug column with Globalize

### DIFF
--- a/Guide.rdoc
+++ b/Guide.rdoc
@@ -480,8 +480,8 @@ languages. If your application only needs to be localized to one or two
 languages, you may wish to consider the {FriendlyId::SimpleI18n SimpleI18n}
 module.
 
-In order to use this module, your model must have a slug column and set the
-field +slug+ as translable with Globalize:
+In order to use this module, your model's translation table must have a slug
+column and must set the field +slug+ as translatable with Globalize:
 
     class Post < ActiveRecord::Base
       translates :title, :slug

--- a/lib/friendly_id/globalize.rb
+++ b/lib/friendly_id/globalize.rb
@@ -13,8 +13,8 @@ languages. If your application only needs to be localized to one or two
 languages, you may wish to consider the {FriendlyId::SimpleI18n SimpleI18n}
 module.
 
-In order to use this module, your model's table must have a slug column, and you
-must set the field +slug+ as translatable with Globalize:
+In order to use this module, your model's translation table must have a slug
+column, and you must set the field +slug+ as translatable with Globalize:
 
     class Post < ActiveRecord::Base
       translates :title, :slug


### PR DESCRIPTION
This adds a point of clarification in the rdoc and inside the globalize module itself to point out that the slug column must be present on the translation table, not the primary model table itself. It also (real friendly-like) corrects some faulty parallelism.

Resolves #293.
