### PR TITLE
Clarify globalize slug documentation further

### DIFF
--- a/Guide.rdoc
+++ b/Guide.rdoc
@@ -480,8 +480,9 @@ languages. If your application only needs to be localized to one or two
 languages, you may wish to consider the {FriendlyId::SimpleI18n SimpleI18n}
 module.
 
-In order to use this module, your model's translation table must have a slug
-column and must set the field +slug+ as translatable with Globalize:
+In order to use this module, your model's table and translation table must both
+have a slug column, and your model must set the +slug+ field as translatable
+with Globalize:
 
     class Post < ActiveRecord::Base
       translates :title, :slug

--- a/lib/friendly_id/globalize.rb
+++ b/lib/friendly_id/globalize.rb
@@ -13,8 +13,9 @@ languages. If your application only needs to be localized to one or two
 languages, you may wish to consider the {FriendlyId::SimpleI18n SimpleI18n}
 module.
 
-In order to use this module, your model's translation table must have a slug
-column, and you must set the field +slug+ as translatable with Globalize:
+In order to use this module, your model's table and translation table must both
+have a slug column, and your model must set the +slug+ field as translatable
+with Globalize:
 
     class Post < ActiveRecord::Base
       translates :title, :slug


### PR DESCRIPTION
In response to @norman's comment [here](https://github.com/norman/friendly_id/pull/308#issuecomment-6763158):

The previous change made in dc78438 lost clarity when it assumed parallelism, when in fact the first object had changed with the same commit. Now it should be clearer that the model must set the slug column translatable, not the translation table.
