### PR TITLE
Require mocha_standalone instead of mocha

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,6 +1,6 @@
 require "rubygems"
 require "bundler/setup"
-require "mocha"
+require "mocha_standalone"
 require "minitest/unit"
 require "active_record"
 require 'active_support/core_ext/time/conversions'


### PR DESCRIPTION
As mentioned in freerange/mocha#88, requiring "mocha" instead of "mocha_standalone" will either fail the tests or deprecation warn (mocha v0.12.0 and v0.12.1, respectively).
