### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ You might also want to watch Ryan Bates's [Railscast on FriendlyId](http://rails
 
     cd my_app
 
-    gem "friendly_id", "~> 4.0.1"
+    gem "friendly_id", "~> 4.0.9"
 
     rails generate scaffold user name:string slug:string
 


### PR DESCRIPTION
Specify newer friendly_id gem after Rails 3.2.11 update. Older 4.0.1 won't work. Fixes #354.
