### PR TITLE
use new ActiveRecord::Generators::Base class for generator

### DIFF
--- a/lib/generators/friendly_id_generator.rb
+++ b/lib/generators/friendly_id_generator.rb
@@ -3,14 +3,15 @@ require "rails/generators/active_record"
 
 # This generator adds a migration for the {FriendlyId::History
 # FriendlyId::History} addon.
-class FriendlyIdGenerator < Rails::Generators::Base
-  include Rails::Generators::Migration
-  extend ActiveRecord::Generators::Migration if defined? ActiveRecord::Generators::Migration
+class FriendlyIdGenerator < ActiveRecord::Generators::Base
+  # ActiveRecord::Generators::Base inherits from Rails::Generators::NamedBase which requires a NAME parameter for the
+  # new table name. Our generator always uses 'friendly_id_slugs', so we just set a random name here.
+  argument :name, type: :string, default: 'random_name'
 
   source_root File.expand_path('../../friendly_id', __FILE__)
 
   # Copies the migration template to db/migrate.
-  def copy_files(*args)
+  def copy_files
     migration_template 'migration.rb', 'db/migrate/create_friendly_id_slugs.rb'
   end
 


### PR DESCRIPTION
Currently, `rails generate friendly_id` raises ``next_migration_number': NotImplementedError` (see #390) because the generator classes has been refactored for Rails 4. This pull request fixes this error by using the correct superclass.
