### PR TITLE
Update examples in scoped.rb to indicated that FriendlyId::Scoped has to...

### DIFF
--- a/lib/friendly_id/scoped.rb
+++ b/lib/friendly_id/scoped.rb
@@ -14,12 +14,16 @@ This allows, for example, two restaurants in different cities to have the slug
 
     class Restaurant < ActiveRecord::Base
       extend FriendlyId
+      include FriendlyId::Scoped
+      
       belongs_to :city
       friendly_id :name, :use => :scoped, :scope => :city
     end
 
     class City < ActiveRecord::Base
       extend FriendlyId
+      include FriendlyId::Scoped
+      
       has_many :restaurants
       friendly_id :name, :use => :slugged
     end
@@ -37,18 +41,24 @@ Additionally, the +:scope+ option can receive an array of scope values:
 
     class Cuisine < ActiveRecord::Base
       extend FriendlyId
+      include FriendlyId::Scoped
+      
       has_many :restaurants
       friendly_id :name, :use => :slugged
     end
 
     class City < ActiveRecord::Base
       extend FriendlyId
+      include FriendlyId::Scoped
+      
       has_many :restaurants
       friendly_id :name, :use => :slugged
     end
 
     class Restaurant < ActiveRecord::Base
       extend FriendlyId
+      include FriendlyId::Scoped
+      
       belongs_to :city
       friendly_id :name, :use => :scoped, :scope => [:city, :cuisine]
     end


### PR DESCRIPTION
Hey guys, 

Not sure this is right, but I only got scopes working by having "include FriendlyId::Scoped" in my model. 

Otherwise I'd get an error like: 
`friendly_id-4.0.9/lib/friendly_id/configuration.rb:77:in block in set': undefined method scope='`

Submitting a pull request to start the discussion, if its wrong, no worries.
