### PR TITLE
Use 4.0 stable whatsnew doc url

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ FriendlyId is compatible with Active Record **3.0** and higher.
 
 FriendlyId 4.x introduces many changes incompatible with 3.x. If you're
 upgrading, please [read the
-docs](http://rubydoc.info/github/norman/friendly_id/master/file/WhatsNew.md) to see what's
+docs](http://rubydoc.info/github/FriendlyId/friendly_id/4.0-stable/file/WhatsNew.md) to see what's
 new.
 
 ## Docs


### PR DESCRIPTION
All of the documentation urls are correct except for this one. The project/documentation has since moved under FriendlyId instead of norman, so this just updates the WhatsNew.md url to be in line with the others.
