### PR TITLE
Using newer instance method rails syntax for migration methods

### DIFF
--- a/lib/friendly_id/migration.rb
+++ b/lib/friendly_id/migration.rb
@@ -1,6 +1,6 @@
 class CreateFriendlyIdSlugs < ActiveRecord::Migration
 
-  def self.up
+  def up
     create_table :friendly_id_slugs do |t|
       t.string   :slug,           :null => false
       t.integer  :sluggable_id,   :null => false
@@ -14,7 +14,7 @@ class CreateFriendlyIdSlugs < ActiveRecord::Migration
     add_index :friendly_id_slugs, :sluggable_type
   end
 
-  def self.down
+  def down
     drop_table :friendly_id_slugs
   end
 end

--- a/lib/friendly_id/simple_i18n.rb
+++ b/lib/friendly_id/simple_i18n.rb
@@ -21,7 +21,7 @@ friendly_id_globalize gem instead.
 
 ### Example migration
 
-    def self.up
+    def up
       create_table :posts do |t|
         t.string :title
         t.string :slug_en

--- a/lib/friendly_id/slugged.rb
+++ b/lib/friendly_id/slugged.rb
@@ -47,7 +47,7 @@ app's behavior and requirements.
 
     # a migration
     class CreatePosts < ActiveRecord::Migration
-      def self.up
+      def up
         create_table :posts do |t|
           t.string :title, :null => false
           t.string :slug, :null => false
@@ -57,7 +57,7 @@ app's behavior and requirements.
         add_index :posts, :slug, :unique => true
       end
 
-      def self.down
+      def down
         drop_table :posts
       end
     end


### PR DESCRIPTION
Apparently using class methods like `self.up` and `self.down` was an older syntax for migrations in Rails. This commit  uses the newer syntax of instance methods. 
