### PR TITLE
Support UUID (and any other non-integer) primary key

### DIFF
--- a/lib/friendly_id/base.rb
+++ b/lib/friendly_id/base.rb
@@ -216,6 +216,10 @@ often better and easier to use {FriendlyId::Slugged slugs}.
         config.model_class = self
       end
     end
+
+    def primary_key_type
+      @primary_key_type ||= columns.find(&:primary).type
+    end
   end
 
   # Instance methods that will be added to all classes using FriendlyId.

--- a/lib/friendly_id/finder_methods.rb
+++ b/lib/friendly_id/finder_methods.rb
@@ -19,7 +19,7 @@ module FriendlyId
       id = args.first
       return super if args.count != 1 || id.unfriendly_id?
       first_by_friendly_id(id).tap {|result| return result unless result.nil?}
-      return super if columns.find{|c| c.primary }.type != :integer || Integer(id, 10) rescue nil
+      return super if potential_primary_key?(id)
       raise ActiveRecord::RecordNotFound
     end
 
@@ -37,6 +37,17 @@ module FriendlyId
     end
 
     private
+
+    def potential_primary_key?(id)
+      case primary_key_type
+      when :integer
+        Integer(id, 10) rescue false
+      when :uuid
+        id.match /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/
+      else
+        true
+      end
+    end
 
     def first_by_friendly_id(id)
       where(friendly_id_config.query_field => id).first

--- a/test/schema.rb
+++ b/test/schema.rb
@@ -23,6 +23,15 @@ module FriendlyId
             end
           end
 
+          tables_with_string_primary_key.each do |table_name|
+            create_table table_name, primary_key: :string_key, id: false do |t|
+              t.string :name
+              t.string :string_key, null: false
+              t.string :slug
+            end
+            add_index table_name, :slug, unique: true
+          end
+
           slugged_tables.each do |table_name|
             add_column table_name, :slug, :string
             add_index  table_name, :slug, :unique => true
@@ -62,6 +71,10 @@ module FriendlyId
 
         def slugged_tables
           %w[journalists articles novelists novels manuals]
+        end
+
+        def tables_with_string_primary_key
+          ["menu_items"]
         end
 
         def scoped_tables

--- a/test/slugged_test.rb
+++ b/test/slugged_test.rb
@@ -205,6 +205,40 @@ class DefaultScopeTest < MiniTest::Unit::TestCase
   end
 end
 
+class StringAsPrimaryKeyFindTest < MiniTest::Unit::TestCase
+  include FriendlyId::Test
+
+  class MenuItem < ActiveRecord::Base
+    extend FriendlyId
+    friendly_id :name, :use => :slugged
+    before_create :init_primary_key
+
+    def self.primary_key 
+      "string_key"
+    end
+
+    private
+    def init_primary_key
+      self.string_key = SecureRandom.uuid
+    end
+  end
+
+  def model_class
+    MenuItem
+  end
+
+  test "should have a string as a primary key" do
+    assert_equal model_class.primary_key, "string_key"
+    assert_equal model_class.columns.find(&:primary).name, "string_key"
+  end
+
+  test "should be findable by the string primary key" do
+    with_instance_of(model_class) do |record|
+      assert model_class.friendly.find record.id
+    end
+  end
+end
+
 class UnderscoreAsSequenceSeparatorRegressionTest < MiniTest::Unit::TestCase
   include FriendlyId::Test
 


### PR DESCRIPTION
Only skip the default find if the primary key is an integer column and the ID is also an integer. For example, I'm using Postgres UUIDs as my primary keys, and using the friendly.find method will never call the default find with a UUID since it is not an integer.
