### PR TITLE
Allow records to reuse their own slugs

### DIFF
--- a/lib/friendly_id/scoped.rb
+++ b/lib/friendly_id/scoped.rb
@@ -126,6 +126,10 @@ an example of one way to set this up:
       friendly_id_config.scope_columns.each do |column|
         relation = relation.where(column => send(column))
       end
+      if changed.include?(friendly_id_config.slug_column)
+        column = self.class.quoted_table_name + '.' + self.class.quoted_primary_key
+        relation = relation.where("#{column} <> ?", send(self.class.primary_key))
+      end
       friendly_id_config.slug_generator_class.new(relation)
     end
     private :slug_generator

--- a/test/scoped_test.rb
+++ b/test/scoped_test.rb
@@ -69,4 +69,13 @@ class ScopedTest < MiniTest::Unit::TestCase
       assert novel3.friendly_id != novel4.friendly_id
     end
   end
+
+  test 'should allow a record to reuse its own slug' do
+    with_instance_of(model_class) do |record|
+      old_id = record.friendly_id
+      record.slug = nil
+      record.save!
+      assert_equal old_id, record.friendly_id
+    end
+  end
 end


### PR DESCRIPTION
@norman

I found this missing features in my current project. When I use scoped and then try to regenerate slug, it's always changed. I notice this and copy the missing features from slugged.

Signed-off-by: Donny Kurnia donnykurnia@gmail.com
