### PR TITLE
Updated README. StackOverflow has merged friendly_id and friendly-id tags.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 Please ask questions on [Stack
 Overflow](http://stackoverflow.com/questions/tagged/friendly-id) using the
-"friendly_id" or "friendly-id" tag. Prior to asking, search and see if your
-question has already been anwered.
+"friendly-id" tag. Prior to asking, search and see if your question has
+already been anwered.
 
 Please only post issues in Github issues for actual bugs.
 


### PR DESCRIPTION
No need to mention friendly_id tag anymore since SO will automatically convert friendly_id to friendly-id at this point and SO convention prefers friendly-id anyway.
