### PR TITLE
Call to_param to ensure we get a string as specified in the rails docs

### DIFF
--- a/lib/friendly_id/base.rb
+++ b/lib/friendly_id/base.rb
@@ -243,7 +243,7 @@ often better and easier to use {FriendlyId::Slugged slugs}.
       if diff = changes[friendly_id_config.query_field]
         diff.first || diff.second
       else
-        friendly_id.presence || super
+        friendly_id.presence.to_param || super
       end
     end
   end

--- a/test/shared.rb
+++ b/test/shared.rb
@@ -151,6 +151,13 @@ module FriendlyId
           end
         end
 
+        test "should return the friendly_id as a string" do
+          with_instance_of(model_class) do |record|
+            record.expects(:friendly_id).returns(5)
+            assert_equal "5", record.to_param
+          end
+        end
+
         test "should return numeric id if the friendly_id is blank" do
           with_instance_of(model_class) do |record|
             record.expects(:friendly_id).returns("  ")


### PR DESCRIPTION
Because of a rewrite in the routes in Rails 4.0.1.rc3 friendly_id causes an issue if the field you are using is numeric.
The to_param method that is included in the model should always return a string.
The easiest way to do this is by calling to_param on the result itself.
