### PR TITLE
Refactoring FriendlyId::Scoped::#slug_generator. Breaking it into two smaller methods

### DIFF
--- a/lib/friendly_id/scoped.rb
+++ b/lib/friendly_id/scoped.rb
@@ -121,7 +121,7 @@ an example of one way to set this up:
       friendly_id_config.scope_columns.sort.map { |column| "#{column}:#{send(column)}" }.join(",")
     end
 
-    def slug_generator
+    def scope_for_slug_generator
       relation = self.class.unscoped.friendly
       friendly_id_config.scope_columns.each do |column|
         relation = relation.where(column => send(column))
@@ -130,7 +130,11 @@ an example of one way to set this up:
         column = self.class.quoted_table_name + '.' + self.class.quoted_primary_key
         relation = relation.where("#{column} <> ?", send(self.class.primary_key))
       end
-      friendly_id_config.slug_generator_class.new(relation)
+      relation
+    end
+    
+    def slug_generator
+      friendly_id_config.slug_generator_class.new(scope_for_slug_generator)
     end
     private :slug_generator
 


### PR DESCRIPTION
So (as you probably know) I have been looking into friendly_id codebase and bugging you guys for sometime. ;)

Anyway, while wanting to reuse some code I came across some code I felt would be helped by some refactoring. So I decided to submit this pull request. 

This refactoring: 
- Doesn't break any existing tests
- Breaks one method into two smaller ones
- Keeps things consistent to how the `Slugged` module is coded
- Improves adherence to SRP 
- Will help me reuse some code if/when it goes live. 
