### PR TITLE
JRuby and Rubinius support in specs, Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: ruby
 rvm:
   - 2.0.0
+  - jruby-19mode
+  - rbx
 env:
   - DB=postgres
   - DB=mysql

--- a/Gemfile
+++ b/Gemfile
@@ -6,10 +6,16 @@ gemspec
 group :development, :test do
   platforms :jruby do
     gem 'activerecord-jdbcsqlite3-adapter', '>= 1.3.0.beta2'
-    gem 'jruby-openssl'
+    gem 'kramdown'
   end
 
-  platforms :ruby do
+  platforms :ruby, :rbx do
     gem 'sqlite3'
+    gem 'redcarpet'
+  end
+
+  platforms :rbx do
+    gem 'rubysl', '~> 2.0'
+    gem 'rubinius-developer_tools'
   end
 end

--- a/friendly_id.gemspec
+++ b/friendly_id.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'i18n'
   s.add_development_dependency 'ffaker'
   s.add_development_dependency 'simplecov'
-  s.add_development_dependency 'redcarpet'
 
   s.description = <<-EOM
 FriendlyId is the "Swiss Army bulldozer" of slugging and permalink plugins for

--- a/gemfiles/Gemfile.rails-4.0.rb
+++ b/gemfiles/Gemfile.rails-4.0.rb
@@ -8,12 +8,19 @@ group :development, :test do
     gem 'activerecord-jdbcsqlite3-adapter', '>= 1.3.0.beta2'
     gem 'activerecord-jdbcmysql-adapter', '>= 1.3.0.beta2'
     gem 'activerecord-jdbcpostgresql-adapter', '>= 1.3.0.beta2'
-    gem 'jruby-openssl'
+    gem 'kramdown'
   end
 
-  platforms :ruby do
+  platforms :ruby, :rbx do
     gem 'sqlite3'
     gem 'mysql2'
     gem 'pg'
+    gem 'redcarpet'
+  end
+
+  platforms :rbx do
+    gem 'rubysl', '~> 2.0'
+    gem 'rubinius-developer_tools'
+    gem 'json'
   end
 end

--- a/gemfiles/Gemfile.rails-stable.rb
+++ b/gemfiles/Gemfile.rails-stable.rb
@@ -13,12 +13,18 @@ group :development, :test do
     gem 'activerecord-jdbcsqlite3-adapter', '>= 1.3.0.beta2'
     gem 'activerecord-jdbcmysql-adapter', '>= 1.3.0.beta2'
     gem 'activerecord-jdbcpostgresql-adapter', '>= 1.3.0.beta2'
-    gem 'jruby-openssl'
+    gem 'kramdown'
   end
 
-  platforms :ruby do
+  platforms :ruby, :rbx do
     gem 'sqlite3'
     gem 'mysql2'
     gem 'pg'
+    gem 'redcarpet'
+  end
+
+  platforms :rbx do
+    gem 'rubysl', '~> 2.0'
+    gem 'rubinius-developer_tools'
   end
 end


### PR DESCRIPTION
1. Updated Gemfile and gemspec so specs run on JRuby and rbx.
2. Added to .travis.yml
