### PR TITLE
Rails 4.1 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,18 @@ env:
 gemfile:
   - gemfiles/Gemfile.rails-4.0.rb
   - gemfiles/Gemfile.rails-stable.rb
+  - gemfiles/Gemfile.rails-4.1.rb
 
 before_script: 'bundle exec rake db:create db:up'
 script: 'COVERAGE=true bundle exec rake test'
+matrix:
+  allow_failures:
+    - rvm: jruby-19mode
+      gemfile: gemfiles/Gemfile.rails-4.1.rb
+      env: DB=postgres
+    - rvm: jruby-19mode
+      gemfile: gemfiles/Gemfile.rails-4.1.rb
+      env: DB=mysql
+    - rvm: jruby-19mode
+      gemfile: gemfiles/Gemfile.rails-4.1.rb
+      env: DB=sqlite3

--- a/friendly_id.gemspec
+++ b/friendly_id.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 1.9.3'
 
-  s.add_dependency 'activerecord', '~> 4.0.0'
+  s.add_dependency 'activerecord', '>= 4.0.0'
 
   s.add_development_dependency 'coveralls'
   s.add_development_dependency 'railties', '~> 4.0.0'

--- a/gemfiles/Gemfile.rails-4.1.rb
+++ b/gemfiles/Gemfile.rails-4.1.rb
@@ -1,0 +1,29 @@
+source 'https://rubygems.org'
+
+gemspec path: '../'
+
+gem 'activerecord', '~> 4.1.0.beta1'
+gem 'railties', '~> 4.1.0.beta1'
+
+# Database Configuration
+group :development, :test do
+  platforms :jruby do
+    gem 'activerecord-jdbcsqlite3-adapter', '>= 1.3.0.beta2'
+    gem 'activerecord-jdbcmysql-adapter', '>= 1.3.0.beta2'
+    gem 'activerecord-jdbcpostgresql-adapter', '>= 1.3.0.beta2'
+    gem 'kramdown'
+  end
+
+  platforms :ruby, :rbx do
+    gem 'sqlite3'
+    gem 'mysql2'
+    gem 'pg'
+    gem 'redcarpet'
+  end
+
+  platforms :rbx do
+    gem 'rubysl', '~> 2.0'
+    gem 'rubinius-developer_tools'
+    gem 'json'
+  end
+end

--- a/lib/friendly_id/finders.rb
+++ b/lib/friendly_id/finders.rb
@@ -63,17 +63,50 @@ for models that use FriendlyId with something similar to the following:
 
 =end
   module Finders
+
+    class AssociationRelationDelegateFinder
+      attr_accessor :model_class
+      def initialize(model_class)
+        self.model_class = model_class
+      end
+
+      def find
+        if is_active_record_4_0?
+          active_record_4_0_class
+        else
+          active_record_4_1_class
+        end
+      end
+
+      private
+
+      def is_active_record_4_0?
+        (ActiveRecord::VERSION::MINOR == 0) && (ActiveRecord::VERSION::MAJOR == 4)
+      end
+
+      # AssociationRelation delegate class for Rails 4.0.x.
+      # As of 1 October 2013 this works on Rails 4-0-stable, but may change.
+      def active_record_4_0_class
+        assocation_relation_class_name = :"ActiveRecord_AssociationRelation_#{model_class.to_s.gsub('::', '_')}"
+        ::ActiveRecord::AssociationRelation.const_get(assocation_relation_class_name)
+      end
+
+      # AssociationRelation delegate class for Rails 4.1.x.
+      # As of 18 December 2013 this works on Rails 4-1-stable, but may change.
+      def active_record_4_1_class
+        model_class.relation_delegate_class(::ActiveRecord::AssociationRelation)
+      end
+    end
+
     def self.included(model_class)
       model_class.instance_eval do
         relation.class.send(:include, friendly_id_config.finder_methods)
       end
 
       # Support for friendly finds on associations for Rails 4.0.1 and above.
-      # As of 1 October 2013 this works on Rails 4-0-stable, but may change.
       if ::ActiveRecord.const_defined?('AssociationRelation')
-        assocation_relation_class_name = :"ActiveRecord_AssociationRelation_#{model_class.to_s.gsub('::', '_')}"
-        association_relation_class = ::ActiveRecord::AssociationRelation.const_get(assocation_relation_class_name)
-        association_relation_class.send(:include, model_class.friendly_id_config.finder_methods)
+        association_relation_delegate_class = AssociationRelationDelegateFinder.new(model_class).find
+        association_relation_delegate_class.send(:include, model_class.friendly_id_config.finder_methods)
       end
     end
   end


### PR DESCRIPTION
1. Update Finders module to look up the correct class-specific ActiveRecord::AssociationRelation for both Rails 4.0.x and 4.1.x
2. Add Rails 4.1.x to tested gemfiles and .travis.yml
3. Temporarily allow failures on Rails 4.1 / JRuby until this issue - https://github.com/jruby/activerecord-jdbc-adapter/pull/523 - is addressed
