### PR TITLE
STI test failure when looking up record from SubClass

### DIFF
--- a/lib/friendly_id/finders.rb
+++ b/lib/friendly_id/finders.rb
@@ -66,10 +66,10 @@ for models that use FriendlyId with something similar to the following:
 
     module ClassMethods
       if (ActiveRecord::VERSION::MAJOR == 4) && (ActiveRecord::VERSION::MINOR == 0)
-         def relation_delegate_class(klass)
-            relation_class_name = :"#{klass.to_s.gsub('::', '_')}_#{self.to_s.gsub('::', '_')}"
-            klass.const_get(relation_class_name)
-          end
+        def relation_delegate_class(klass)
+          relation_class_name = :"#{klass.to_s.gsub('::', '_')}_#{self.to_s.gsub('::', '_')}"
+          klass.const_get(relation_class_name)
+        end
       end
     end
 

--- a/test/sti_test.rb
+++ b/test/sti_test.rb
@@ -8,7 +8,7 @@ class StiTest < MiniTest::Unit::TestCase
 
   class Journalist < ActiveRecord::Base
     extend FriendlyId
-    friendly_id :name, :use => :slugged
+    friendly_id :name, :use => [:slugged]
   end
 
   class Editorialist < Journalist
@@ -59,7 +59,6 @@ class StiTest < MiniTest::Unit::TestCase
       assert_match(/foo-bar-.+/, editoralist.slug)
     end
   end
-
 end
 
 class StiTestWithHistory < StiTest
@@ -74,4 +73,64 @@ class StiTestWithHistory < StiTest
   def model_class
     Editorialist
   end
+end
+
+
+class StiTestWithFinders < MiniTest::Unit::TestCase
+
+  include FriendlyId::Test
+
+  class Journalist < ActiveRecord::Base
+    extend FriendlyId
+    friendly_id :name, :use => [:slugged, :finders]
+  end
+
+  class Editorialist < Journalist
+    extend FriendlyId
+    friendly_id :name, :use => [:slugged, :finders]
+  end
+
+  def model_class
+    Editorialist
+  end
+
+  test "friendly_id slugs should be looked up from sub class with friendly" do
+    transaction do
+      editoralist = model_class.create! :name => 'foo bar'
+      assert_equal editoralist, model_class.friendly.find(editoralist.slug)
+    end
+  end
+
+  test "friendly_id slugs should be looked up from sub class" do
+    transaction do
+      editoralist = model_class.create! :name => 'foo bar'
+      assert_equal editoralist, model_class.find(editoralist.slug)
+    end
+  end
+
+end
+
+class StiTestSubClass < MiniTest::Unit::TestCase
+
+  include FriendlyId::Test
+
+  class Journalist < ActiveRecord::Base
+  end
+
+  class Editorialist < Journalist
+    extend FriendlyId
+    friendly_id :name, :use => [:slugged, :finders]
+  end
+
+  def model_class
+    Editorialist
+  end
+
+  test "friendly_id slugs can be created and looked up from sub class" do
+    transaction do
+      editoralist = model_class.create! :name => 'foo bar'
+      assert_equal editoralist, model_class.find(editoralist.slug)
+    end
+  end
+
 end


### PR DESCRIPTION
``` ruby
class Journalist < ActiveRecord::Base
  extend FriendlyId
  friendly_id :name, :use => :slugged
end

class Editorialist < Journalist
  extend FriendlyId
  friendly_id :name, :use => :slugged
end

editorialist = Editorialist.create name: "foo"

Editorialist.find editorialist.slug
# => Couldn't find Editorialist 
```

Also:

``` ruby
class Journalist < ActiveRecord::Base
end

class Editorialist < Journalist
  extend FriendlyId
  friendly_id :name, :use => :slugged
end

Editorialist.create name: "foo"
# => Couldn't create Editorialist 
`undefined method `exists_by_friendly_id?'`
```
