### PR TITLE
#dup with unslugged model causes undefined method error

### DIFF
--- a/lib/friendly_id/base.rb
+++ b/lib/friendly_id/base.rb
@@ -249,7 +249,7 @@ often better and easier to use {FriendlyId::Slugged slugs}.
 
     # Clears slug on duplicate records when calling `dup`.
     def dup
-      super.tap { |duplicate| duplicate.slug = nil }
+      super.tap { |duplicate| duplicate.slug = nil if duplicate.respond_to?('slug=') }
     end
   end
 end


### PR DESCRIPTION
In lib/friendly_id/base.rb:252, as introduced in SHA: aa3b4a69fbe1bed107312195bf1a4345489dd770:

```
    def dup
      super.tap { |duplicate| duplicate.slug = nil }
    end
```

However, suppose we have a User with just `friendly_id :login` - no extra slug. #slug= is not defined, and therefore some_user.dup fails.

My patch just makes the dup check if slug= is defined before using it.
