### PR TITLE
Ensure Travis runs without error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ rvm:
   - 2.0.0
   - 2.1.0
   - jruby-19mode
-  - rbx
+  - rbx-2
 env:
   - DB=postgres
   - DB=mysql

--- a/gemfiles/Gemfile.rails-4.1.rb
+++ b/gemfiles/Gemfile.rails-4.1.rb
@@ -2,8 +2,8 @@ source 'https://rubygems.org'
 
 gemspec path: '../'
 
-gem 'activerecord', '~> 4.1.0.beta1'
-gem 'railties', '~> 4.1.0.beta1'
+gem 'activerecord', '~> 4.1.0'
+gem 'railties', '~> 4.1.0'
 
 # Database Configuration
 group :development, :test do


### PR DESCRIPTION
1. Update .travis.yml to use rbx-2.
2. Remove beta reference from Rails 4.1 gemfile

Travis is still showing intermittent test failures, but the Rubinius tests are no longer erroring out.
