### PR TITLE
Add a transaction so that these objects are cleared after the test run

### DIFF
--- a/test/slugged_test.rb
+++ b/test/slugged_test.rb
@@ -313,10 +313,12 @@ class UnderscoreAsSequenceSeparatorRegressionTest < MiniTest::Unit::TestCase
 
   test "should not create duplicate slugs" do
     3.times do
-      begin
-        assert Manual.create! :name => "foo"
-      rescue
-        flunk "Tried to insert duplicate slug"
+      transaction do
+        begin
+          assert Manual.create! :name => "foo"
+        rescue
+          flunk "Tried to insert duplicate slug"
+        end
       end
     end
   end


### PR DESCRIPTION
Gets the specs to green and fixes issues #565 

Core problem was a missing transaction block around a spec in slugged_test.rb.  Once this spec ran, it left Manual objects with a slug of 'foo' in the database.   Those conflicted with Manual objects being created in the history_test.rb specs.

Intermittency of the failures was caused by ordering.  If the a spec in history_test.rb ran before the spec in slugged_test.rb it would pass, otherwise it would fail.
