### PR TITLE
[Fix] Solved a problem caused by 'where.not' when using the globalize gem

### DIFF
--- a/lib/friendly_id/scoped.rb
+++ b/lib/friendly_id/scoped.rb
@@ -122,13 +122,12 @@ an example of one way to set this up:
     end
 
     def scope_for_slug_generator
-      arel_table = self.class.arel_table
       relation = self.class.unscoped.friendly
       friendly_id_config.scope_columns.each do |column|
         relation = relation.where(column => send(column))
       end
       primary_key_name = self.class.primary_key
-      relation.where(arel_table[primary_key_name].not_eq(send(primary_key_name)))
+      relation.where(self.class.arel_table[primary_key_name].not_eq(send(primary_key_name)))
     end
     private :scope_for_slug_generator
 

--- a/lib/friendly_id/slugged.rb
+++ b/lib/friendly_id/slugged.rb
@@ -310,11 +310,10 @@ Github issue](https://github.com/norman/friendly_id/issues/185) for discussion.
     private :set_slug
 
     def scope_for_slug_generator
-      arel_table = self.class.base_class.arel_table
       scope = self.class.base_class.unscoped
       scope = scope.friendly unless scope.respond_to?(:exists_by_friendly_id?)
       primary_key_name = self.class.primary_key
-      scope.where(arel_table[primary_key_name].not_eq(send(primary_key_name)))
+      scope.where(self.class.base_class.arel_table[primary_key_name].not_eq(send(primary_key_name)))
     end
     private :scope_for_slug_generator
 


### PR DESCRIPTION
I recently found out that using `friendly_id` + `globalize` will break when the app is running with postgres as database.

In particular, calling `.where.not( ... )` on a scope will append `AND (NOT ('--- id: '))` to queries, thus breaking the query on the database.

This fix converts the `.where.not()` in a generic `where()` clause through `arel` syntax.
