### PR TITLE
Added scenario to check that scoped generates slug before validation.

### DIFF
--- a/test/scoped_test.rb
+++ b/test/scoped_test.rb
@@ -81,4 +81,12 @@ class ScopedTest < Minitest::Test
     end
   end
 
+  test 'should generate slug before validation' do
+    transaction do
+      n = Novel.new(:name => 'Crime and Punishment')
+      assert n.valid?
+      assert_equal 'crime-and-punishment', n.slug
+    end
+  end
+
 end


### PR DESCRIPTION
Hey @norman @xymbol! 

I added a scenario to check that `scoped` generates the slug before validation for new records. 

I don't know if this is a scenario that is covered in another test file. 

Please check it out and let me know if it's useful/correct.

Thanks! 
