### PR TITLE
Using :scoped with :history causes Unknown column '<table_name>.scope' when regenerating slug

### DIFF
--- a/lib/friendly_id/history.rb
+++ b/lib/friendly_id/history.rb
@@ -106,7 +106,7 @@ method.
       return relation if new_record?
       relation = relation.merge(Slug.where('sluggable_id <> ?', id))
       if friendly_id_config.uses?(:scoped)
-        relation = relation.where(:scope => serialized_scope)
+        relation = relation.where(Slug.arel_table[:scope].eq(serialized_scope))
       end
       relation
     end


### PR DESCRIPTION
If I have a model like this:

``` ruby
class Restaurant < ActiveRecord::Base
  extend FriendlyId
  belongs_to :city
  friendly_id :name, :use => [:scoped, :history], :scope => :city
end
```

The following will result in an ActiveRecord::StatementInvalid: Mysql2::Error: Unknown column 'restaurants.scope' exception:

``` ruby
restaurant = Restaurant.new
restaurant.city = City.new
restaurant.name = "Joe's Diner"
restaurant.save

restaurant.title = "Bob's Diner"
restaurant.slug = nil
restaurant.save # throws exception(Unknown column 'restaurants.scope' )
```

This pull request fixes the offending where condition to use `friendly_id_slugs.scope`
