### PR TITLE
Small fix: work properly with the `annotate` gem

### DIFF
--- a/lib/friendly_id.rb
+++ b/lib/friendly_id.rb
@@ -86,6 +86,7 @@ module FriendlyId
   #
   # For examples of this, see the source for {Scoped.included}.
   def self.extended(model_class)
+    return if model_class.is_a? Module
     return if model_class.respond_to? :friendly_id
     class << model_class
       alias relation_without_friendly_id relation


### PR DESCRIPTION
I got the following error with `annotate` and fixed it with this oneliner.

```
% annotate --exclude tests,fixtures,factories
/var/lib/gems/1.9.1/gems/friendly_id-4.0.10.1/lib/friendly_id.rb:82:in `singletonclass': undefined method `relation' for class `Module' (NameError)
        from /var/lib/gems/1.9.1/gems/friendly_id-4.0.10.1/lib/friendly_id.rb:81:in `extended'
        from /home/cies/repos/work/ooievaarspas/app/models/concerns/offerable.rb:3:in `extend'
        from /home/cies/repos/work/ooievaarspas/app/models/concerns/offerable.rb:3:in `<module:Offerable>'
        from /home/cies/repos/work/ooievaarspas/app/models/concerns/offerable.rb:1:in `<top (required)>'
        from /var/lib/gems/1.9.1/gems/zeus-0.15.1/lib/zeus/load_tracking.rb:50:in `load'
        from /var/lib/gems/1.9.1/gems/zeus-0.15.1/lib/zeus/load_tracking.rb:50:in `load'
        from /var/lib/gems/1.9.1/gems/activesupport-3.2.17/lib/active_support/dependencies.rb:469:in `block in load_file'
        from /var/lib/gems/1.9.1/gems/activesupport-3.2.17/lib/active_support/dependencies.rb:639:in `new_constants_in'
        from /var/lib/gems/1.9.1/gems/activesupport-3.2.17/lib/active_support/dependencies.rb:468:in `load_file'
        from /var/lib/gems/1.9.1/gems/activesupport-3.2.17/lib/active_support/dependencies.rb:353:in `require_or_load'
        from /var/lib/gems/1.9.1/gems/activesupport-3.2.17/lib/active_support/dependencies.rb:313:in `depend_on'
        from /var/lib/gems/1.9.1/gems/activesupport-3.2.17/lib/active_support/dependencies.rb:225:in `require_dependency'
        from /var/lib/gems/1.9.1/gems/railties-3.2.17/lib/rails/engine.rb:444:in `block (2 levels) in eager_load!'
        from /var/lib/gems/1.9.1/gems/railties-3.2.17/lib/rails/engine.rb:443:in `each'
        from /var/lib/gems/1.9.1/gems/railties-3.2.17/lib/rails/engine.rb:443:in `block in eager_load!'
        from /var/lib/gems/1.9.1/gems/railties-3.2.17/lib/rails/engine.rb:441:in `each'
        from /var/lib/gems/1.9.1/gems/railties-3.2.17/lib/rails/engine.rb:441:in `eager_load!'
        from /var/lib/gems/1.9.1/gems/railties-3.2.17/lib/rails/railtie/configurable.rb:30:in `method_missing'
        from /var/lib/gems/1.9.1/gems/annotate-2.6.5/lib/annotate.rb:109:in `eager_load'
        from /var/lib/gems/1.9.1/gems/annotate-2.6.5/bin/annotate:155:in `<top (required)>'
        from /usr/local/bin/annotate:23:in `load'
        from /usr/local/bin/annotate:23:in `<main>'
```
