### PR TITLE
Rails 4.2 support, part 1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,19 +9,11 @@ env:
   - DB=mysql
 gemfile:
   - gemfiles/Gemfile.rails-4.0.rb
-  - gemfiles/Gemfile.rails-stable.rb
   - gemfiles/Gemfile.rails-4.1.rb
+  - gemfiles/Gemfile.rails-4.2.rb
 
 before_script: 'bundle exec rake db:create db:up'
 script: 'COVERALLS=true bundle exec rake test'
 matrix:
   allow_failures:
-    - rvm: jruby-19mode
-      gemfile: gemfiles/Gemfile.rails-4.1.rb
-      env: DB=postgres
-    - rvm: jruby-19mode
-      gemfile: gemfiles/Gemfile.rails-4.1.rb
-      env: DB=mysql
-    - rvm: jruby-19mode
-      gemfile: gemfiles/Gemfile.rails-4.1.rb
-      env: DB=sqlite3
+    - gemfile: gemfiles/Gemfile.rails-4.2.rb

--- a/gemfiles/Gemfile.rails-4.2.rb
+++ b/gemfiles/Gemfile.rails-4.2.rb
@@ -2,10 +2,12 @@ source 'https://rubygems.org'
 
 gemspec path: '../'
 
-gem 'rails', github: 'rails/rails', branch: '4-1-stable' do
+gem 'rails', github: 'rails/rails', tag: 'v4.2.0.beta2' do
   gem 'activerecord'
   gem 'railties'
 end
+
+gem 'i18n', '0.7.0.beta1'
 
 # Database Configuration
 group :development, :test do

--- a/lib/friendly_id/history.rb
+++ b/lib/friendly_id/history.rb
@@ -87,7 +87,11 @@ method.
       private
 
       def first_by_friendly_id(id)
-        where(friendly_id_config.query_field => id).first ||
+        matching_record = where(friendly_id_config.query_field => id).first
+        matching_record || slug_table_record(id)
+      end
+
+      def slug_table_record(id)
         select(quoted_table_name + '.*').joins(:slugs).where(slug_history_clause(id)).first
       end
 

--- a/lib/friendly_id/scoped.rb
+++ b/lib/friendly_id/scoped.rb
@@ -163,7 +163,8 @@ an example of one way to set this up:
       private
 
       def reflection_foreign_key(scope)
-        model_class.reflections[scope].try(:foreign_key)
+        reflection = model_class.reflections[scope] || model_class.reflections[scope.to_s]
+        reflection.try(:foreign_key)
       end
     end
   end

--- a/test/history_test.rb
+++ b/test/history_test.rb
@@ -195,9 +195,9 @@ class HistoryTestWithFriendlyFinders < HistoryTest
         record.save!
         begin
           assert model_class.find(old_friendly_id)
-          assert model_class.exists?(old_friendly_id), "should exist? by old id"
-        rescue ActiveRecord::RecordNotFound
-          flunk "Could not find record by old id"
+          assert model_class.exists?(old_friendly_id), "should exist? by old id for #{model_class.name}"
+        rescue ActiveRecord::RecordNotFound => e
+          flunk "Could not find record by old id for #{model_class.name}"
         end
       end
     end


### PR DESCRIPTION
1. Move the Rails-stable gemfile to Rails-4.2, and update to use the Rails 4.2 dependencies.  As a side note, the Rails-stable gemfile was actually just testing 4.1
2. Support Symbol (Rails 4.0/4.1) or String (Rails 4.2) keys when looking up reflection
3. Split up a method in lib/history.rb for easier debugging
4. Add some test-specific detail to an error message for a spec failing under Rails 4.2
5. Update Travis CI config to account for these changes.

There's still one failing spec on Rails 4.2, as well as a number of deprecation warnings.  More to come.
