### PR TITLE
fix(Slugged+History+Scoped): fix SQL errors when using the 3 plugins together

### DIFF
--- a/lib/friendly_id/history.rb
+++ b/lib/friendly_id/history.rb
@@ -108,11 +108,14 @@ method.
     def scope_for_slug_generator
       relation = super
       return relation if new_record?
-      relation = relation.merge(Slug.where('sluggable_id <> ?', id))
+
+      # joins(:slugs) is needed but will be added to the relation by `exists_by_friendly_id?`
+      sw = Slug.where('sluggable_id <> ?', id)
       if friendly_id_config.uses?(:scoped)
-        relation = relation.where(:scope => serialized_scope)
+        # scope is in Slug not in the model table
+        sw = sw.where(:scope => serialized_scope)
       end
-      relation
+      relation.merge(sw)
     end
 
     def create_slug


### PR DESCRIPTION
`scope_for_slug_generator` method on not new records, with History and Scoped enabled, produced invalid SQL statements.

``` sql
SELECT "restaurants".* FROM "restaurants"  
  WHERE "restaurants"."city_id" = 1 
  AND ("restaurants"."id" != 1) 
  AND (sluggable_id <> 1) 
  AND "restaurants"."scope" = 'city_id:1'
```

SCOPE is part of the Slug model, not the Restaurant model:

``` sql
SELECT "restaurants".* FROM "restaurants"  
  WHERE "restaurants"."city_id" = 1 
  AND ("restaurants"."id" != 1) 
  AND (sluggable_id <> 1) 
  AND "friendly_id_slugs"."scope" = 'city_id:1'
```
