### PR TITLE
Undefined variable warning

### DIFF
--- a/lib/friendly_id/slugged.rb
+++ b/lib/friendly_id/slugged.rb
@@ -342,12 +342,12 @@ Github issue](https://github.com/norman/friendly_id/issues/185) for discussion.
       # sequence_separator} configuration option.
       # @return String The sequence separator string. Defaults to "`-`".
       def sequence_separator
-        @sequence_separator or defaults[:sequence_separator]
+        @sequence_separator ||= defaults[:sequence_separator]
       end
 
       # The column that will be used to store the generated slug.
       def slug_column
-        @slug_column or defaults[:slug_column]
+        @slug_column ||= defaults[:slug_column]
       end
     end
   end


### PR DESCRIPTION
Hi, I'm getting a warning of undefined variable for @slug_column in line 350, it's not been defined anywhere else, but in any case I'm keeping the variable and just changing the syntax. The same thing is happening in line 345, although, no warnings are triggered. Hope it helps, thanks for the gem!
