### PR TITLE
Addon for numerically sequential slugs

### DIFF
--- a/lib/friendly_id.rb
+++ b/lib/friendly_id.rb
@@ -42,13 +42,14 @@ with numeric ids:
 =end
 module FriendlyId
 
-  autoload :History,    "friendly_id/history"
-  autoload :Slug,       "friendly_id/slug"
-  autoload :SimpleI18n, "friendly_id/simple_i18n"
-  autoload :Reserved,   "friendly_id/reserved"
-  autoload :Scoped,     "friendly_id/scoped"
-  autoload :Slugged,    "friendly_id/slugged"
-  autoload :Finders,    "friendly_id/finders"
+  autoload :History,             "friendly_id/history"
+  autoload :Slug,                "friendly_id/slug"
+  autoload :SimpleI18n,          "friendly_id/simple_i18n"
+  autoload :Reserved,            "friendly_id/reserved"
+  autoload :Scoped,              "friendly_id/scoped"
+  autoload :Slugged,             "friendly_id/slugged"
+  autoload :Finders,             "friendly_id/finders"
+  autoload :SequentiallySlugged, "friendly_id/sequentially_slugged"
 
   # Instances of these classes will never be considered a friendly id.
   # @see FriendlyId::ObjectUtils#friendly_id

--- a/lib/friendly_id/sequentially_slugged.rb
+++ b/lib/friendly_id/sequentially_slugged.rb
@@ -1,0 +1,67 @@
+module FriendlyId
+  module SequentiallySlugged
+    def self.setup(model_class)
+      model_class.friendly_id_config.use :slugged
+    end
+
+    def should_generate_new_friendly_id?
+      send(friendly_id_config.base).present? && super
+    end
+
+    def resolve_friendly_id_conflict(candidate_slugs)
+      SequentialSlugCalculator.new(scope_for_slug_generator,
+                                  candidate_slugs.first,
+                                  friendly_id_config.slug_column,
+                                  friendly_id_config.sequence_separator).next_slug
+    end
+
+    class SequentialSlugCalculator
+      attr_accessor :scope, :slug, :slug_column, :sequence_separator
+
+      def initialize(scope, slug, slug_column, sequence_separator)
+        @scope = scope
+        @slug = slug
+        @slug_column = scope.connection.quote_column_name(slug_column)
+        @sequence_separator = sequence_separator
+      end
+
+      def next_slug
+        slug + sequence_separator + next_sequence_number.to_s
+      end
+
+    private
+
+      def next_sequence_number
+        if last_sequence_number == 0
+          2
+        else
+          last_sequence_number + 1
+        end
+      end
+
+      def last_sequence_number
+        slug_conflicts.last.split("#{slug}#{sequence_separator}").last.to_i
+      end
+
+      def slug_conflicts
+        scope.
+          where(conflict_query, slug, sequential_slug_matcher).
+          order(ordering_query).pluck(slug_column)
+      end
+
+      def conflict_query
+        "#{slug_column} = ? OR #{slug_column} LIKE ?"
+      end
+
+      def sequential_slug_matcher
+        "#{slug}#{sequence_separator}%"
+      end
+
+      # Return the unnumbered (shortest) slug first, followed by the numbered ones
+      # in ascending order.
+      def ordering_query
+        "LENGTH(#{slug_column}) ASC, #{slug_column} ASC"
+      end
+    end
+  end
+end

--- a/lib/friendly_id/sequentially_slugged.rb
+++ b/lib/friendly_id/sequentially_slugged.rb
@@ -32,15 +32,13 @@ module FriendlyId
     private
 
       def next_sequence_number
-        if last_sequence_number == 0
-          2
-        else
-          last_sequence_number + 1
-        end
+        last_sequence_number ? last_sequence_number + 1 : 2
       end
 
       def last_sequence_number
-        slug_conflicts.last.split("#{slug}#{sequence_separator}").last.to_i
+        if match = /#{slug}#{sequence_separator}(\d+)/.match(slug_conflicts.last)
+          match[1].to_i
+        end
       end
 
       def slug_conflicts

--- a/test/sequentially_slugged_test.rb
+++ b/test/sequentially_slugged_test.rb
@@ -64,6 +64,15 @@ class SequentiallySluggedTest < TestCaseClass
     end
   end
 
+  test "should correctly sequence slugs that begin with a number" do
+    transaction do
+      record1 = model_class.create! :name => "2010 to 2015 Records"
+      assert_equal "2010-to-2015-records", record1.slug
+      record2 = model_class.create! :name => "2010 to 2015 Records"
+      assert_equal "2010-to-2015-records-2", record2.slug
+    end
+  end
+
   test "should sequence with a custom sequence separator" do
     model_class = Class.new(ActiveRecord::Base) do
       self.table_name = "novelists"


### PR DESCRIPTION
This provides an addon that enables sequential slugs for conflict resolution, mimicking the behaviour of friendly_id v4.

Well formed candidates combined with UUIDs as a fallback will almost always be the better solution for resolving slug conflicts. That said, there are circumstances when this is either not possible or undesirable. For example, either good candidates cannot be formed, or the existing behaviour needs to be maintained for consistency.

I have recently had to deal with this situation whilst upgrading a [large Rails 3 application to Rails 4](https://github.com/alphagov/whitehall/pull/1958). In this case it's not possible to form appropriate candidates for many of the sluggable models, and UUIDs would make new URLs inconsistent and "ugly". Ultimately it's both cheaper and far easier for the business (in this case the [UK government](https://github.com/alphagov)) to maintain the existing behaviour than it would be to retrospectively migrate to the candidate/UUID-based approach.

I have intentionally left out any documentation pending feedback. I'm assuming that if this is to make it into friendly_id, it would have to be made clear that it's meant as a last resort for those unable to use the preferred candidate/UUID-based approach.

/cc @parndt