### PR TITLE
Make Candidates#each iterable without block.

### DIFF
--- a/lib/friendly_id/candidates.rb
+++ b/lib/friendly_id/candidates.rb
@@ -23,6 +23,9 @@ module FriendlyId
       unless pre_candidates.all? {|x| reserved?(x)}
         pre_candidates.reject! {|x| reserved?(x)}
       end
+
+      return pre_candidates unless block_given?
+
       pre_candidates.each {|x| yield x}
     end
 

--- a/test/candidates_test.rb
+++ b/test/candidates_test.rb
@@ -114,4 +114,30 @@ class CandidatesTest < TestCaseClass
     end
   end
 
+  test "allows to iterate through candidates without passing block" do
+    klass = Class.new model_class do
+      def slug_candidates
+        :name
+      end
+    end
+    with_instances_of klass do |_, city|
+      candidates = FriendlyId::Candidates.new(city, city.slug_candidates)
+      assert_equal candidates.each, ['new-york']
+    end
+  end
+
+  test "iterates through candidates with passed block" do
+    klass = Class.new model_class do
+      def slug_candidates
+        :name
+      end
+    end
+    with_instances_of klass do |_, city|
+      collected_candidates = []
+      candidates = FriendlyId::Candidates.new(city, city.slug_candidates)
+      candidates.each { |candidate| collected_candidates << candidate }
+      assert_equal collected_candidates, ['new-york']
+    end
+  end
+
 end


### PR DESCRIPTION
Hi

The mean aim of this commit is to provide access to generated slug candidates without direct AR manipulations
```ruby 
FriendlyId::Candidates.new(model, model.slug_candidates).each 
# => ["ergonomic-zero-es-africa", "ergonomic-zero-es-africa-100"]
# instead of 
# LocalJumpError: no block given (yield)
``` 
So, it seems reasonable for me to use this syntax instead of calling #save. It can be written to return Enumerator instead of array, but it will be not so readable and will complicate method.