### PR TITLE
CI: allow postgres + jruby + activerecord 4.2 failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,6 @@ matrix:
 
 sudo: false
 
-# Per https://github.com/travis-ci/travis-ci/issues/2821
-install: bundle install --retry=3
-
 before_script: 'bundle exec rake db:create db:up'
 
 script: 'COVERALLS=true bundle exec rake test'

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,12 @@ gemfile:
   - gemfiles/Gemfile.rails-4.1.rb
   - gemfiles/Gemfile.rails-4.2.rb
 
+matrix:
+  allow_failures:
+    - rvm: jruby-19mode
+      gemfile: gemfiles/Gemfile.rails-4.2.rb
+      env: DB=postgres
+
 sudo: false
 
 # Per https://github.com/travis-ci/travis-ci/issues/2821


### PR DESCRIPTION
@norman I can't figure out the failure, and the driver itself says it's not quite ready for ActiveRecord 4.2 so this seems acceptable for now.

I've also removed a now useless rbx + Travis CI workaround where we had to override the bundle install command.  This should play much more nicely with bundle caching now.