### PR TITLE
Fix minor typo in documentation

### DIFF
--- a/lib/friendly_id/initializer.rb
+++ b/lib/friendly_id/initializer.rb
@@ -65,7 +65,7 @@ FriendlyId.defaults do |config|
   #
   # As of FriendlyId 5.0, new slugs are generated only when the slug field is
   # nil, but if you're using a column as your base method can change this
-  # behavior by overriding the `should_generate_new_friendly_id` method that
+  # behavior by overriding the `should_generate_new_friendly_id?` method that
   # FriendlyId adds to your model. The change below makes FriendlyId 5.0 behave
   # more like 4.0.
   #


### PR DESCRIPTION
The method name is `should_generate_new_friendly_id?` not `should_generate_new_friendly_id`.

That seems rather important. :-)