### PR TITLE
ensure slug history prefers the record that most recently used the slug

### DIFF
--- a/lib/friendly_id/history.rb
+++ b/lib/friendly_id/history.rb
@@ -95,7 +95,7 @@ method.
       end
 
       def slug_table_record(id)
-        select(quoted_table_name + '.*').joins(:slugs).where(slug_history_clause(id)).order(Slug.arel_table[:created_at].desc).first
+        select(quoted_table_name + '.*').joins(:slugs).where(slug_history_clause(id)).order(Slug.arel_table[:id].desc).first
       end
 
       def slug_history_clause(id)

--- a/lib/friendly_id/history.rb
+++ b/lib/friendly_id/history.rb
@@ -95,7 +95,7 @@ method.
       end
 
       def slug_table_record(id)
-        select(quoted_table_name + '.*').joins(:slugs).where(slug_history_clause(id)).first
+        select(quoted_table_name + '.*').joins(:slugs).where(slug_history_clause(id)).order(Slug.arel_table[:created_at].desc).first
       end
 
       def slug_history_clause(id)

--- a/test/history_test.rb
+++ b/test/history_test.rb
@@ -117,6 +117,19 @@ class HistoryTest < Minitest::Test
     end
   end
 
+  test "should prefer product that used slug most recently" do
+    transaction do
+      first_record = model_class.create! name: "foo"
+      second_record = model_class.create! name: "bar"
+
+      first_record.update! slug: "not_foo"
+      second_record.update! slug: "foo" #now both records have used foo; second_record most recently
+      second_record.update! slug: "not_bar"
+
+      assert_equal model_class.friendly.find("foo"), second_record
+    end
+  end
+
   test 'should name table according to prefix and suffix' do
     transaction do
       begin


### PR DESCRIPTION
Slugs can be reused by different model instances when the slug is reassigned directly, as in `model_instance.slug = "value_already_in_history"`. This means you can have more than one instance of the slug value for the same type in the history. 
Currently, in this scenario, the first model instance to use the slug value will win out in a history search, because the `slug_table_record` method relies on natural sorting (by id) and selects the first record.
It seems more logical to retrieve the model instance that most recently used the slug value, which would actually be the last record with the slug value in the slug history table. 

This PR sets an explicit descending order by created_at on the history table search, so that the selected model is the last one to use the target slug value.