### PR TITLE
Don't calculate all changes just to check if the param field has changed

### DIFF
--- a/lib/friendly_id/base.rb
+++ b/lib/friendly_id/base.rb
@@ -244,7 +244,8 @@ often better and easier to use {FriendlyId::Slugged slugs}.
 
     # Either the friendly_id, or the numeric id cast to a string.
     def to_param
-      if diff = changes[friendly_id_config.query_field]
+      if attribute_changed?(friendly_id_config.query_field)
+        diff = changes[friendly_id_config.query_field]
         diff.first || diff.second
       else
         friendly_id.presence.to_param || super


### PR DESCRIPTION
Starting with Rails 4.2, calculating the `changes` hash in activerecord is much more expensive since it now tracks in-place changes in json/jsonb/hstore fields. We noticed a ~10x hit to performance due to these changes being calculated on every `to_param` call on some of our models with large json fields. 

This change simply checks for changes in a less expensive way before calculating the `changes` hash if the param field has indeed changed. 

All tests still pass and I didn't see a need to add additional testing.