### PR TITLE
Possibly optimize the unfriendly_id? check

### DIFF
--- a/friendly_id.gemspec
+++ b/friendly_id.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.require_paths     = ["lib"]
   s.license           = 'MIT'
 
-  s.required_ruby_version = '>= 2.0.0'
+  s.required_ruby_version = '>= 1.9.3'
 
   s.add_dependency 'activerecord', '>= 4.0.0'
 

--- a/friendly_id.gemspec
+++ b/friendly_id.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.require_paths     = ["lib"]
   s.license           = 'MIT'
 
-  s.required_ruby_version = '>= 1.9.3'
+  s.required_ruby_version = '>= 2.1.0'
 
   s.add_dependency 'activerecord', '>= 4.0.0'
 

--- a/friendly_id.gemspec
+++ b/friendly_id.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.require_paths     = ["lib"]
   s.license           = 'MIT'
 
-  s.required_ruby_version = '>= 2.1.0'
+  s.required_ruby_version = '>= 2.0.0'
 
   s.add_dependency 'activerecord', '>= 4.0.0'
 

--- a/lib/friendly_id.rb
+++ b/lib/friendly_id.rb
@@ -51,19 +51,6 @@ module FriendlyId
   autoload :Finders,             "friendly_id/finders"
   autoload :SequentiallySlugged, "friendly_id/sequentially_slugged"
 
-  # Instances of these classes will never be considered a friendly id.
-  # @see FriendlyId::ObjectUtils#friendly_id
-  UNFRIENDLY_CLASSES = [
-    ActiveRecord::Base,
-    Array,
-    FalseClass,
-    Hash,
-    NilClass,
-    Numeric,
-    Symbol,
-    TrueClass
-  ]
-
   # FriendlyId takes advantage of `extended` to do basic model setup, primarily
   # extending {FriendlyId::Base} to add {FriendlyId::Base#friendly_id
   # friendly_id} as a class method.

--- a/lib/friendly_id/finder_methods.rb
+++ b/lib/friendly_id/finder_methods.rb
@@ -2,6 +2,8 @@ module FriendlyId
 
   module FinderMethods
 
+    using ::FriendlyId::ObjectUtils
+
     # Finds a record using the given id.
     #
     # If the id is "unfriendly", it will call the original find method.

--- a/lib/friendly_id/finder_methods.rb
+++ b/lib/friendly_id/finder_methods.rb
@@ -19,7 +19,7 @@ module FriendlyId
     # @raise ActiveRecord::RecordNotFound
     def find(*args)
       id = args.first
-      return super if args.count != 1 || id.unfriendly_id?
+      return super if args.count != 1 || !id.possibly_friendly_id?
       first_by_friendly_id(id).tap {|result| return result unless result.nil?}
       return super if potential_primary_key?(id)
       raise ActiveRecord::RecordNotFound

--- a/lib/friendly_id/finder_methods.rb
+++ b/lib/friendly_id/finder_methods.rb
@@ -1,8 +1,8 @@
+using FriendlyId::ObjectUtils
+
 module FriendlyId
 
   module FinderMethods
-
-    using ::FriendlyId::ObjectUtils
 
     # Finds a record using the given id.
     #

--- a/lib/friendly_id/finder_methods.rb
+++ b/lib/friendly_id/finder_methods.rb
@@ -1,5 +1,3 @@
-using FriendlyId::ObjectUtils
-
 module FriendlyId
 
   module FinderMethods

--- a/lib/friendly_id/finder_methods.rb
+++ b/lib/friendly_id/finder_methods.rb
@@ -17,7 +17,7 @@ module FriendlyId
     # @raise ActiveRecord::RecordNotFound
     def find(*args)
       id = args.first
-      return super if args.count != 1 || !id.possibly_friendly_id?
+      return super if args.count != 1 || id.unfriendly_id?
       first_by_friendly_id(id).tap {|result| return result unless result.nil?}
       return super if potential_primary_key?(id)
       raise ActiveRecord::RecordNotFound

--- a/lib/friendly_id/object_utils.rb
+++ b/lib/friendly_id/object_utils.rb
@@ -1,4 +1,4 @@
-module FriendlyId::ObjectUtils
+module FriendlyId
 
   # Instances of these classes will never be considered a friendly id.
   UNFRIENDLY_CLASSES = [
@@ -19,7 +19,7 @@ module FriendlyId::ObjectUtils
   # cleaner than adding a module method to {FriendlyId}. I've given the methods
   # names that unambigously refer to the library of their origin, which should
   # be sufficient to avoid conflicts with other libraries.
-  refine Object do
+  module ObjectUtils
 
     # True if the id is definitely friendly, false if definitely unfriendly,
     # else nil.
@@ -57,22 +57,27 @@ module FriendlyId::ObjectUtils
     end
   end
 
-  refine String do
+  module StringUtils
     # Fast response to this check without creating an interim String
     def possibly_friendly_id?
       true
     end
   end
 
-  UNFRIENDLY_CLASSES.each do |klass|
-    refine klass do
-      def friendly_id?
-        false
-      end
-      def unfriendly_id?
-        true
-      end
+  module UnfriendlyUtils
+    def friendly_id?
+      false
+    end
+    def unfriendly_id?
+      true
+    end
+    def possibly_friendly_id?
+      false
     end
   end
 
 end
+
+Object.send :include, FriendlyId::ObjectUtils
+String.send :include, FriendlyId::StringUtils
+FriendlyId::UNFRIENDLY_CLASSES.each {|klass| klass.send(:include, FriendlyId::UnfriendlyUtils)}

--- a/lib/friendly_id/object_utils.rb
+++ b/lib/friendly_id/object_utils.rb
@@ -50,18 +50,6 @@ module FriendlyId
     def unfriendly_id?
       val = friendly_id? ; !val unless val.nil?
     end
-
-    # True unless the id is definitely unfriendly
-    def possibly_friendly_id?
-      !unfriendly_id?
-    end
-  end
-
-  module StringUtils
-    # Fast response to this check without creating an interim String
-    def possibly_friendly_id?
-      true
-    end
   end
 
   module UnfriendlyUtils
@@ -71,13 +59,9 @@ module FriendlyId
     def unfriendly_id?
       true
     end
-    def possibly_friendly_id?
-      false
-    end
   end
 
 end
 
 Object.send :include, FriendlyId::ObjectUtils
-String.send :include, FriendlyId::StringUtils
-FriendlyId::UNFRIENDLY_CLASSES.each {|klass| klass.send(:include, FriendlyId::UnfriendlyUtils)}
+FriendlyId::UNFRIENDLY_CLASSES.each { |klass| klass.send(:include, FriendlyId::UnfriendlyUtils) }

--- a/lib/friendly_id/object_utils.rb
+++ b/lib/friendly_id/object_utils.rb
@@ -1,4 +1,4 @@
-module FriendlyId
+module FriendlyId::ObjectUtils
 
   # Instances of these classes will never be considered a friendly id.
   UNFRIENDLY_CLASSES = [
@@ -19,7 +19,7 @@ module FriendlyId
   # cleaner than adding a module method to {FriendlyId}. I've given the methods
   # names that unambigously refer to the library of their origin, which should
   # be sufficient to avoid conflicts with other libraries.
-  module ObjectUtils
+  refine Object do
 
     # True if the id is definitely friendly, false if definitely unfriendly,
     # else nil.
@@ -51,22 +51,16 @@ module FriendlyId
       val = friendly_id? ; !val unless val.nil?
     end
   end
-  module StringUtils
-    def unfriendly_id?
-      # Note: This now returns false even in cases where the original method returned nil
-      false
-    end
-  end
-  module UnfriendlyUtils
-    def friendly_id?
-      false
-    end
-    def unfriendly_id?
-      true
-    end
-  end
-end
 
-Object.send :include, FriendlyId::ObjectUtils
-String.send :include, FriendlyId::StringUtils
-FriendlyId::UNFRIENDLY_CLASSES.each {|klass| klass.send(:include, FriendlyId::UnfriendlyUtils)}
+  UNFRIENDLY_CLASSES.each do |klass|
+    refine klass do
+      def friendly_id?
+        false
+      end
+      def unfriendly_id?
+        true
+      end
+    end
+  end
+
+end

--- a/lib/friendly_id/object_utils.rb
+++ b/lib/friendly_id/object_utils.rb
@@ -50,6 +50,18 @@ module FriendlyId::ObjectUtils
     def unfriendly_id?
       val = friendly_id? ; !val unless val.nil?
     end
+
+    # True unless the id is definitely unfriendly
+    def possibly_friendly_id?
+      !unfriendly_id?
+    end
+  end
+
+  refine String do
+    # Fast response to this check without creating an interim String
+    def possibly_friendly_id?
+      true
+    end
   end
 
   UNFRIENDLY_CLASSES.each do |klass|

--- a/lib/friendly_id/object_utils.rb
+++ b/lib/friendly_id/object_utils.rb
@@ -1,4 +1,17 @@
 module FriendlyId
+
+  # Instances of these classes will never be considered a friendly id.
+  UNFRIENDLY_CLASSES = [
+    ActiveRecord::Base,
+    Array,
+    FalseClass,
+    Hash,
+    NilClass,
+    Numeric,
+    Symbol,
+    TrueClass
+  ]
+
   # Utility methods for determining whether any object is a friendly id.
   #
   # Monkey-patching Object is a somewhat extreme measure not to be taken lightly
@@ -11,7 +24,7 @@ module FriendlyId
     # True if the id is definitely friendly, false if definitely unfriendly,
     # else nil.
     #
-    # An object is considired "definitely unfriendly" if its class is or
+    # An object is considered "definitely unfriendly" if its class is or
     # inherits from ActiveRecord::Base, Array, Hash, NilClass, Numeric, or
     # Symbol.
     #
@@ -27,11 +40,7 @@ module FriendlyId
     #     "123".friendly_id?                #=> nil
     #     "abc123".friendly_id?             #=> true
     def friendly_id?
-      # Considered unfriendly if this is an instance of an unfriendly class or
-      # one of its descendants.
-      if FriendlyId::UNFRIENDLY_CLASSES.detect {|klass| self.class <= klass}
-        false
-      elsif respond_to?(:to_i) && to_i.to_s != to_s
+      if respond_to?(:to_i) && to_i.to_s != to_s
         true
       end
     end
@@ -42,6 +51,22 @@ module FriendlyId
       val = friendly_id? ; !val unless val.nil?
     end
   end
+  module StringUtils
+    def unfriendly_id?
+      # Note: This now returns false even in cases where the original method returned nil
+      false
+    end
+  end
+  module UnfriendlyUtils
+    def friendly_id?
+      false
+    end
+    def unfriendly_id?
+      true
+    end
+  end
 end
 
 Object.send :include, FriendlyId::ObjectUtils
+String.send :include, FriendlyId::StringUtils
+FriendlyId::UNFRIENDLY_CLASSES.each {|klass| klass.send(:include, FriendlyId::UnfriendlyUtils)}

--- a/test/benchmarks/object_utils.rb
+++ b/test/benchmarks/object_utils.rb
@@ -39,20 +39,26 @@ N = 5_000_000
 
 Benchmark.bmbm do |x|
   x.report('integer friendly_id?') { N.times {test_integer.friendly_id?} }
+  x.report('integer possibly_friendly_id?') { N.times {test_integer.possibly_friendly_id?} }
   x.report('integer unfriendly_id?') { N.times {test_integer.unfriendly_id?} }
 
   x.report('AR::Base friendly_id?') { N.times {test_active_record_object.friendly_id?} }
+  x.report('AR::Base possibly_friendly_id?') { N.times {test_active_record_object.possibly_friendly_id?} }
   x.report('AR::Base unfriendly_id?') { N.times {test_active_record_object.unfriendly_id?} }
 
   x.report('hash friendly_id?') { N.times {test_hash.friendly_id?} }
+  x.report('hash possibly_friendly_id?') { N.times {test_hash.possibly_friendly_id?} }
   x.report('hash unfriendly_id?') { N.times {test_hash.unfriendly_id?} }
 
   x.report('nil friendly_id?') { N.times {test_nil.friendly_id?} }
+  x.report('nil possibly_friendly_id?') { N.times {test_nil.possibly_friendly_id?} }
   x.report('nil unfriendly_id?') { N.times {test_nil.unfriendly_id?} }
 
   x.report('numeric string friendly_id?') { N.times {test_numeric_string.friendly_id?} }
+  x.report('numeric string possibly_friendly_id?') { N.times {test_numeric_string.possibly_friendly_id?} }
   x.report('numeric string unfriendly_id?') { N.times {test_numeric_string.unfriendly_id?} }
 
   x.report('test_string friendly_id?') { N.times {test_string.friendly_id?} }
+  x.report('test_string possibly_friendly_id?') { N.times {test_string.possibly_friendly_id?} }
   x.report('test_string unfriendly_id?') { N.times {test_string.unfriendly_id?} }
 end

--- a/test/benchmarks/object_utils.rb
+++ b/test/benchmarks/object_utils.rb
@@ -26,37 +26,19 @@ require File.expand_path("../../helper", __FILE__)
 
 Book = Class.new ActiveRecord::Base
 
-test_integer = 123
-test_active_record_object = Book.new
-test_hash = {:name=>'joe'}
-test_nil = nil
-test_numeric_string = "123"
-test_string = "abc123"
-
+TEST_CASES = {
+  'integer' => 123,
+  'AR::Base' => Book.new,
+  'hash' => {:name=>'joe'},
+  'nil' => nil,
+  'numeric_string' => '123',
+  'string' => 'abc123'
+}
 N = 5_000_000
 
 Benchmark.bmbm do |x|
-  x.report('integer friendly_id?') { N.times {test_integer.friendly_id?} }
-  x.report('integer possibly_friendly_id?') { N.times {test_integer.possibly_friendly_id?} }
-  x.report('integer unfriendly_id?') { N.times {test_integer.unfriendly_id?} }
-
-  x.report('AR::Base friendly_id?') { N.times {test_active_record_object.friendly_id?} }
-  x.report('AR::Base possibly_friendly_id?') { N.times {test_active_record_object.possibly_friendly_id?} }
-  x.report('AR::Base unfriendly_id?') { N.times {test_active_record_object.unfriendly_id?} }
-
-  x.report('hash friendly_id?') { N.times {test_hash.friendly_id?} }
-  x.report('hash possibly_friendly_id?') { N.times {test_hash.possibly_friendly_id?} }
-  x.report('hash unfriendly_id?') { N.times {test_hash.unfriendly_id?} }
-
-  x.report('nil friendly_id?') { N.times {test_nil.friendly_id?} }
-  x.report('nil possibly_friendly_id?') { N.times {test_nil.possibly_friendly_id?} }
-  x.report('nil unfriendly_id?') { N.times {test_nil.unfriendly_id?} }
-
-  x.report('numeric string friendly_id?') { N.times {test_numeric_string.friendly_id?} }
-  x.report('numeric string possibly_friendly_id?') { N.times {test_numeric_string.possibly_friendly_id?} }
-  x.report('numeric string unfriendly_id?') { N.times {test_numeric_string.unfriendly_id?} }
-
-  x.report('test_string friendly_id?') { N.times {test_string.friendly_id?} }
-  x.report('test_string possibly_friendly_id?') { N.times {test_string.possibly_friendly_id?} }
-  x.report('test_string unfriendly_id?') { N.times {test_string.unfriendly_id?} }
+  TEST_CASES.each do |name, variable|
+    x.report("#{name} friendly_id?") { N.times {variable.friendly_id?} }
+    x.report("#{name} unfriendly_id?") { N.times {variable.unfriendly_id?} }
+  end
 end

--- a/test/benchmarks/object_utils.rb
+++ b/test/benchmarks/object_utils.rb
@@ -1,5 +1,7 @@
 require File.expand_path("../../helper", __FILE__)
 
+using FriendlyId::ObjectUtils
+
 # This benchmark compares the timings of the friendly_id? and unfriendly_id? on various objects
 #
 # integer friendly_id?            6.370000   0.000000   6.370000 (  6.380925)

--- a/test/benchmarks/object_utils.rb
+++ b/test/benchmarks/object_utils.rb
@@ -1,7 +1,5 @@
 require File.expand_path("../../helper", __FILE__)
 
-using FriendlyId::ObjectUtils
-
 # This benchmark compares the timings of the friendly_id? and unfriendly_id? on various objects
 #
 # integer friendly_id?            6.370000   0.000000   6.370000 (  6.380925)

--- a/test/object_utils_test.rb
+++ b/test/object_utils_test.rb
@@ -1,7 +1,5 @@
 require "helper"
 
-using FriendlyId::ObjectUtils
-
 class ObjectUtilsTest < TestCaseClass
 
   include FriendlyId::Test

--- a/test/object_utils_test.rb
+++ b/test/object_utils_test.rb
@@ -8,21 +8,38 @@ class ObjectUtilsTest < TestCaseClass
 
   test "strings with letters are friendly_ids" do
     assert "a".friendly_id?
+    assert "a".possibly_friendly_id?
+    refute "a".unfriendly_id?
   end
 
   test "integers should be unfriendly ids" do
+    refute 1.friendly_id?
+    refute 1.possibly_friendly_id?
     assert 1.unfriendly_id?
   end
 
-  test "numeric strings are neither friendly nor unfriendly" do
-    assert_equal nil, "1".friendly_id?
-    assert_equal nil, "1".unfriendly_id?
+  test "numeric strings are neither friendly nor unfriendly but are possibly friendly" do
+    assert_nil "1".friendly_id?
+    assert "1".possibly_friendly_id?
+    assert_nil "1".unfriendly_id?
   end
 
   test "ActiveRecord::Base instances should be unfriendly_ids" do
     model_class = Class.new(ActiveRecord::Base) do
       self.table_name = "authors"
     end
+    refute model_class.new.friendly_id?
+    refute model_class.new.possibly_friendly_id?
     assert model_class.new.unfriendly_id?
   end
+
+  test "any object that responds to to_i and to_s" do
+    TestClass=Struct.new(:to_i,:to_s)
+    numericish_string_object = TestClass.new(123, "123abc")
+
+    assert numericish_string_object.friendly_id?
+    assert numericish_string_object.possibly_friendly_id?
+    refute numericish_string_object.unfriendly_id?
+  end
+
 end

--- a/test/object_utils_test.rb
+++ b/test/object_utils_test.rb
@@ -6,19 +6,16 @@ class ObjectUtilsTest < TestCaseClass
 
   test "strings with letters are friendly_ids" do
     assert "a".friendly_id?
-    assert "a".possibly_friendly_id?
     refute "a".unfriendly_id?
   end
 
   test "integers should be unfriendly ids" do
     refute 1.friendly_id?
-    refute 1.possibly_friendly_id?
     assert 1.unfriendly_id?
   end
 
-  test "numeric strings are neither friendly nor unfriendly but are possibly friendly" do
+  test "numeric strings are neither friendly nor unfriendly" do
     assert_nil "1".friendly_id?
-    assert "1".possibly_friendly_id?
     assert_nil "1".unfriendly_id?
   end
 
@@ -27,7 +24,6 @@ class ObjectUtilsTest < TestCaseClass
       self.table_name = "authors"
     end
     refute model_class.new.friendly_id?
-    refute model_class.new.possibly_friendly_id?
     assert model_class.new.unfriendly_id?
   end
 
@@ -36,7 +32,6 @@ class ObjectUtilsTest < TestCaseClass
     numericish_string_object = TestClass.new(123, "123abc")
 
     assert numericish_string_object.friendly_id?
-    assert numericish_string_object.possibly_friendly_id?
     refute numericish_string_object.unfriendly_id?
   end
 

--- a/test/object_utils_test.rb
+++ b/test/object_utils_test.rb
@@ -13,9 +13,9 @@ class ObjectUtilsTest < TestCaseClass
     assert 1.unfriendly_id?
   end
 
-  test "numeric strings are neither friendly nor unfriendly" do
+  test "numeric strings are not friendly but are unfriendly" do
     assert_equal nil, "1".friendly_id?
-    assert_equal nil, "1".unfriendly_id?
+    assert_equal false, "1".unfriendly_id?
   end
 
   test "ActiveRecord::Base instances should be unfriendly_ids" do

--- a/test/object_utils_test.rb
+++ b/test/object_utils_test.rb
@@ -1,10 +1,10 @@
 require "helper"
 
+using FriendlyId::ObjectUtils
 
 class ObjectUtilsTest < TestCaseClass
 
   include FriendlyId::Test
-  using FriendlyId::ObjectUtils
 
   test "strings with letters are friendly_ids" do
     assert "a".friendly_id?

--- a/test/object_utils_test.rb
+++ b/test/object_utils_test.rb
@@ -4,6 +4,7 @@ require "helper"
 class ObjectUtilsTest < TestCaseClass
 
   include FriendlyId::Test
+  using FriendlyId::ObjectUtils
 
   test "strings with letters are friendly_ids" do
     assert "a".friendly_id?
@@ -13,9 +14,9 @@ class ObjectUtilsTest < TestCaseClass
     assert 1.unfriendly_id?
   end
 
-  test "numeric strings are not friendly but are unfriendly" do
+  test "numeric strings are neither friendly nor unfriendly" do
     assert_equal nil, "1".friendly_id?
-    assert_equal false, "1".unfriendly_id?
+    assert_equal nil, "1".unfriendly_id?
   end
 
   test "ActiveRecord::Base instances should be unfriendly_ids" do


### PR DESCRIPTION
The FinderMethods' find() does an `unfriendly_id?` check on the `id` before performing the query.
The logic for that check is a little complex since it also handles the unknown (nil) case.

It seems that the primary cases that need to be handled are String and Numeric. This commit
fast-paths those checks so that Strings always are alway not unfriendly and are checked by the finder and Numerics always immediately pass on to `super`. All `unfriendly_id?` checks are done without allocating any new objects.

This commit changes the monkey-patching of Object, which of course isn't great, but that door has already been opened. Another option would be to stop using `unfriendly_id?` as the finder check condition and implement a new method optimized for Strings and Numerics.

Here are the benchmarks of the new approach. Two things to note...
* This is for 5 million iterations. Relative to the finder `find()`, this is only a 3-5% improvement against a local DB and slight memory improvement.
* In the existing code, the order of a class in the `UNFRIENDLY_CLASSES` array impacts speed. So Numeric could be moved first even if no other change was made.

Before
```
------------------------------------------------------------------------
Using ruby 2.2.2 AR 4.2.1 with sqlite3 (in-memory)
Rehearsal -----------------------------------------------------------------
integer friendly_id?            6.530000   0.010000   6.540000 (  6.533914)
integer unfriendly_id?          6.780000   0.000000   6.780000 (  6.788747)
AR::Base friendly_id?           2.290000   0.000000   2.290000 (  2.284586)
AR::Base unfriendly_id?         2.560000   0.000000   2.560000 (  2.568194)
hash friendly_id?               5.240000   0.010000   5.250000 (  5.243626)
hash unfriendly_id?             5.460000   0.000000   5.460000 (  5.460569)
nil friendly_id?                5.690000   0.000000   5.690000 (  5.697026)
nil unfriendly_id?              5.980000   0.010000   5.990000 (  5.985974)
numeric string friendly_id?     8.640000   0.000000   8.640000 (  8.645938)
numeric string unfriendly_id?   9.620000   0.020000   9.640000 (  9.661533)
test_string friendly_id?        8.290000   0.000000   8.290000 (  8.292507)
test_string unfriendly_id?      8.450000   0.010000   8.460000 (  8.456376)
------------------------------------------------------- total: 75.590000sec

                                    user     system      total        real
integer friendly_id?            6.400000   0.000000   6.400000 (  6.401500)
integer unfriendly_id?          6.740000   0.000000   6.740000 (  6.736401)
AR::Base friendly_id?           2.220000   0.010000   2.230000 (  2.218202)
AR::Base unfriendly_id?         2.510000   0.000000   2.510000 (  2.518849)
hash friendly_id?               5.060000   0.000000   5.060000 (  5.067301)
hash unfriendly_id?             5.420000   0.000000   5.420000 (  5.420728)
nil friendly_id?                5.550000   0.000000   5.550000 (  5.551557)
nil unfriendly_id?              5.940000   0.010000   5.950000 (  5.947000)
numeric string friendly_id?     8.400000   0.000000   8.400000 (  8.405858)
numeric string unfriendly_id?   8.800000   0.000000   8.800000 (  8.800442)
test_string friendly_id?        8.080000   0.010000   8.090000 (  8.082986)
test_string unfriendly_id?      9.270000   0.020000   9.290000 (  9.308659)
```
After
```
Using ruby 2.2.2 AR 4.2.1 with sqlite3 (in-memory)
Rehearsal -----------------------------------------------------------------
integer friendly_id?            0.300000   0.000000   0.300000 (  0.302883)
integer unfriendly_id?          0.320000   0.000000   0.320000 (  0.313744)
AR::Base friendly_id?           0.290000   0.000000   0.290000 (  0.299272)
AR::Base unfriendly_id?         0.310000   0.000000   0.310000 (  0.302496)
hash friendly_id?               0.320000   0.000000   0.320000 (  0.319220)
hash unfriendly_id?             0.310000   0.000000   0.310000 (  0.315932)
nil friendly_id?                0.300000   0.000000   0.300000 (  0.300949)
nil unfriendly_id?              0.310000   0.000000   0.310000 (  0.313623)
numeric string friendly_id?     1.660000   0.000000   1.660000 (  1.667411)
numeric string unfriendly_id?   0.320000   0.000000   0.320000 (  0.319070)
test_string friendly_id?        1.330000   0.000000   1.330000 (  1.331005)
test_string unfriendly_id?      0.310000   0.000000   0.310000 (  0.309833)
-------------------------------------------------------- total: 6.080000sec

                                    user     system      total        real
integer friendly_id?            0.340000   0.000000   0.340000 (  0.332969)
integer unfriendly_id?          0.310000   0.000000   0.310000 (  0.311426)
AR::Base friendly_id?           0.310000   0.000000   0.310000 (  0.311694)
AR::Base unfriendly_id?         0.320000   0.000000   0.320000 (  0.319094)
hash friendly_id?               0.330000   0.000000   0.330000 (  0.321552)
hash unfriendly_id?             0.300000   0.000000   0.300000 (  0.304965)
nil friendly_id?                0.320000   0.000000   0.320000 (  0.319326)
nil unfriendly_id?              0.330000   0.000000   0.330000 (  0.325399)
numeric string friendly_id?     1.650000   0.000000   1.650000 (  1.650626)
numeric string unfriendly_id?   0.310000   0.000000   0.310000 (  0.311350)
test_string friendly_id?        1.330000   0.010000   1.340000 (  1.336598)
test_string unfriendly_id?      0.310000   0.000000   0.310000 (  0.311427)
```