### PR TITLE
Return nil if slug cannot be generated using string concatenation

### DIFF
--- a/lib/friendly_id/sequentially_slugged.rb
+++ b/lib/friendly_id/sequentially_slugged.rb
@@ -26,6 +26,7 @@ module FriendlyId
       end
 
       def next_slug
+        return nil unless slug.present?
         slug + sequence_separator + next_sequence_number.to_s
       end
 

--- a/test/sequentially_slugged_test.rb
+++ b/test/sequentially_slugged_test.rb
@@ -93,4 +93,9 @@ class SequentiallySluggedTest < TestCaseClass
     record = model_class.create!(:name => '')
     assert_nil record.slug
   end
+
+  test "should not generate a slug when the sluggable attribute is nil" do
+    record = model_class.create!(:name => nil)
+    assert_nil record.slug
+  end
 end


### PR DESCRIPTION
Under some circumstances*, when entering

    def next_slug
      slug + sequence_separator + next_sequence_number.to_s
    end

slug and scope may be nil. I'd suggest to add  a guard condition that returns nil if slug cannot be generated using '+' operator or restore the 4.x code where you used string interpolation.

Apparently I couldn't reproduce the cases where 'next' fails in my legacy app that I'm upgrading to Rails 4, so the test I added doesn't bring much and can be removed from the PR. I think that the crucial line is the guard condition.


* I've noticed that it happens when the record is new_record? (not persistent). It fails on generating slug for new record.

UPDATE: actually this is not a good solution, it seems that it's better if the app fails than if it produces empty slugs.  It seems to be related with my Rspec suite and mocking .