### PR TITLE
Added function to strip out possessive apostrophes

### DIFF
--- a/lib/friendly_id/slugged.rb
+++ b/lib/friendly_id/slugged.rb
@@ -288,7 +288,18 @@ Github issue](https://github.com/norman/friendly_id/issues/185) for discussion.
     # @param [#to_s] value The value used as the basis of the slug.
     # @return The candidate slug text, without a sequence.
     def normalize_friendly_id(value)
-      value.to_s.parameterize
+      strip_posessive_apostrophes(value).parameterize
+    end
+
+
+    # Removes single apostrophes indicating possesion
+    # Like "boy's", "girl's", etc
+    # BEFORE parameterizing, so we get
+    # boys, girls
+    # rather than
+    # boy-s, girls-s
+    def strip_posessive_apostrophes(value)
+      value.to_s.gsub(/'s /,'s ').gsub(/'s$/,'s')
     end
 
     # Whether to generate a new slug.

--- a/test/slugged_test.rb
+++ b/test/slugged_test.rb
@@ -190,6 +190,17 @@ class SlugGeneratorTest < TestCaseClass
     end
   end
 
+  test "should correctly sequence slugs with single possessive apostrophes" do
+    transaction do
+      record1 = Novelist.create! :name => "bull's eye"
+      assert_equal 'bulls_eye', record1.slug
+      record2 = Novelist.create! :name => "red bull's eye"
+      assert_equal 'red_bulls_eye', record2.slug
+      record3 = Novelist.create! :name => "red bull's"
+      assert_equal 'red_bulls', record3.slug
+    end
+  end
+
   test "should correctly sequence numeric slugs" do
     transaction do
       n2 = 2.times.map {Article.create :name => '123'}.last


### PR DESCRIPTION
Our SEO types tell us that slugs with possessive apostrophes split out are bad for search scores

So logan-s-run scores worse than logans-run if you're searching for "Logan's Run"

I've added a patch (and tests) to produce the logans-run version