### PR TITLE
Fix sequentially_slugged bugs

### DIFF
--- a/gemfiles/Gemfile.rails-4.0.rb
+++ b/gemfiles/Gemfile.rails-4.0.rb
@@ -17,7 +17,7 @@ group :development, :test do
 
   platforms :ruby, :rbx do
     gem 'sqlite3'
-    gem 'mysql2'
+    gem 'mysql2', '~> 0.3.10'
     gem 'pg'
     gem 'redcarpet'
   end

--- a/gemfiles/Gemfile.rails-4.1.rb
+++ b/gemfiles/Gemfile.rails-4.1.rb
@@ -16,7 +16,7 @@ group :development, :test do
 
   platforms :ruby, :rbx do
     gem 'sqlite3'
-    gem 'mysql2'
+    gem 'mysql2', '~> 0.3.13'
     gem 'pg'
     gem 'redcarpet'
   end

--- a/gemfiles/Gemfile.rails-4.2.rb
+++ b/gemfiles/Gemfile.rails-4.2.rb
@@ -16,7 +16,7 @@ group :development, :test do
 
   platforms :ruby, :rbx do
     gem 'sqlite3'
-    gem 'mysql2'
+    gem 'mysql2', '~> 0.3.13'
     gem 'pg'
     gem 'redcarpet'
   end

--- a/lib/friendly_id/sequentially_slugged.rb
+++ b/lib/friendly_id/sequentially_slugged.rb
@@ -26,7 +26,7 @@ module FriendlyId
       end
 
       def next_slug
-        slug + sequence_separator + next_sequence_number.to_s
+        [slug, next_sequence_number].compact.join(sequence_separator)
       end
 
     private

--- a/lib/friendly_id/sequentially_slugged.rb
+++ b/lib/friendly_id/sequentially_slugged.rb
@@ -36,9 +36,12 @@ module FriendlyId
       end
 
       def last_sequence_number
-        if match = /#{slug}#{sequence_separator}(\d+)\z/.match(slug_conflicts.last)
-          match[1].to_i
+        slug_conflicts.reverse_each do |conflict|
+          match = /#{slug}#{sequence_separator}(\d+)\z/.match(conflict)
+          return match[1].to_i if match
         end
+
+        nil
       end
 
       def slug_conflicts

--- a/test/sequentially_slugged_test.rb
+++ b/test/sequentially_slugged_test.rb
@@ -13,6 +13,23 @@ class SequentiallySluggedTest < TestCaseClass
     Article
   end
 
+  class City < ActiveRecord::Base
+    extend FriendlyId
+    friendly_id :slug_candidates, use: :sequentially_slugged
+
+    def slug_candidates
+      [name, [name, code]]
+    end
+  end
+
+  def slug_candidates_model_class
+    City
+  end
+
+  test "should not raise error when validating with nil slug candidates" do
+    slug_candidates_model_class.new.valid?
+  end
+
   test "should generate numerically sequential slugs" do
     transaction do
       records = 12.times.map { model_class.create! :name => "Some news" }

--- a/test/sequentially_slugged_test.rb
+++ b/test/sequentially_slugged_test.rb
@@ -30,6 +30,18 @@ class SequentiallySluggedTest < TestCaseClass
     slug_candidates_model_class.new.valid?
   end
 
+  test "should not raise error when generating numerical slugs with multiple candidate columns" do
+    record_1 = slug_candidates_model_class.create!(:name => "Toronto", :code => "YYZ")
+    record_2 = slug_candidates_model_class.create!(:name => "Toronto", :code => "YYZ")
+    record_3 = slug_candidates_model_class.create!(:name => "Toronto", :code => "YYZ")
+    record_4 = slug_candidates_model_class.create!(:name => "Toronto", :code => "YYZ")
+
+    assert_equal 'toronto', record_1.slug
+    assert_equal 'toronto-yyz', record_2.slug
+    assert_equal 'toronto-2', record_3.slug
+    assert_equal 'toronto-3', record_4.slug
+  end
+
   test "should generate numerically sequential slugs" do
     transaction do
       records = 12.times.map { model_class.create! :name => "Some news" }


### PR DESCRIPTION
As you suggested at #702, I tried the unreleased version with my projects and ran into some issues I think this PR should solve:

- Validating a record with sequential slugs would raise an error if the first candidate slug was nil.
- Using sequential slugs and candidate together arose some errors when calculating the sequential slug at some situations.