### PR TITLE
#to_param should work with a changed but unsaved slug

### DIFF
--- a/lib/friendly_id/base.rb
+++ b/lib/friendly_id/base.rb
@@ -246,7 +246,7 @@ often better and easier to use {FriendlyId::Slugged slugs}.
     def to_param
       if attribute_changed?(friendly_id_config.query_field)
         diff = changes[friendly_id_config.query_field]
-        diff.first || diff.second
+        diff.second || diff.first
       else
         friendly_id.presence.to_param || super
       end

--- a/test/slugged_test.rb
+++ b/test/slugged_test.rb
@@ -133,6 +133,14 @@ class SluggedTest < TestCaseClass
     end
   end
 
+  test "to_param should work with changed but unsaved slug" do
+    with_instance_of(model_class) do |record|
+      old_id = record.friendly_id
+      record.slug = 'foobar'
+      assert_equal 'foobar', record.to_param
+    end
+  end
+
 end
 
 class SlugGeneratorTest < TestCaseClass


### PR DESCRIPTION
This code is meant to address the issue that @andoq noted in his [May 15, 2012, comment](https://github.com/norman/friendly_id/issues/259#issuecomment-5730841): 

"shouldn't diff.second always be the default? Diff's come back as [old_value, new_value], and it seems like you'd want to use the new_value, and diff.first is the old value."

We're running into problems getting an updated url from an unsaved object.... its giving us the old slug, not the new slug.

```
(byebug) changes
  {"title"=>["Some Title", "Some New Title"], "slug"=>["some-title", "some-new-title"], "updated_at"=>[Thu, 08 Oct 2015 17:50:49 UTC +00:00, Thu, 08 Oct 2015 17:50:49 UTC +00:00]}
(byebug) changes['slug']
  some-title
  some-new-title
(byebug) changes['slug'].first
  some-title
(byebug) changes['slug'].second
  some-new-title
(byebug) to_param
  some-title
```

Reversing the order, like I am doing in this PR, gives the intended behavior: the new slug is prioritized over the old slug. 

I say "intended behavior" because the commit message on the [commit that added this in](https://github.com/norman/friendly_id/commit/71f73ddd097021b69bf4e0b47504d7fb7c390b70) was "return old slug if new slug is nil". In fact, the commit did the opposite: it returned the new slug if the old slug is nil.
