### PR TITLE
Add a meaningful message to AR::RecordNotFound

### DIFF
--- a/lib/friendly_id/finder_methods.rb
+++ b/lib/friendly_id/finder_methods.rb
@@ -20,7 +20,7 @@ module FriendlyId
       return super if args.count != 1 || id.unfriendly_id?
       first_by_friendly_id(id).tap {|result| return result unless result.nil?}
       return super if potential_primary_key?(id)
-      raise ActiveRecord::RecordNotFound
+      raise ActiveRecord::RecordNotFound, "can't find record with friendly id: #{id.inspect}"
     end
 
     # Returns true if a record with the given id exists.


### PR DESCRIPTION
That would greatly improve the debugging experience.