### PR TITLE
Update docs to use v5.0+ syntax for finding

### DIFF
--- a/lib/friendly_id/history.rb
+++ b/lib/friendly_id/history.rb
@@ -41,7 +41,7 @@ method.
       ...
 
       def find_post
-        @post = Post.find params[:id]
+        @post = Post.friendly.find params[:id]
 
         # If an old id or a numeric id was used to find the record, then
         # the request path will not match the post_path, and we should do

--- a/lib/friendly_id/simple_i18n.rb
+++ b/lib/friendly_id/simple_i18n.rb
@@ -37,15 +37,15 @@ friendly_id_globalize gem instead.
 Finds will take into consideration the current locale:
 
     I18n.locale = :es
-    Post.find("la-guerra-de-las-galaxias")
+    Post.friendly.find("la-guerra-de-las-galaxias")
     I18n.locale = :en
-    Post.find("star-wars")
+    Post.friendly.find("star-wars")
 
 To find a slug by an explicit locale, perform the find inside a block
 passed to I18n's `with_locale` method:
 
     I18n.with_locale(:es) do
-      Post.find("la-guerra-de-las-galaxias")
+      Post.friendly.find("la-guerra-de-las-galaxias")
     end
 
 ### Creating Records


### PR DESCRIPTION
Since including `finders` isn't mentioned (and it's out of scope), we should include the 5.0+ syntax instead of the old one.