### PR TITLE
Use the request slug instead of the whole path

### DIFF
--- a/lib/friendly_id/history.rb
+++ b/lib/friendly_id/history.rb
@@ -44,9 +44,9 @@ method.
         @post = Post.find params[:id]
 
         # If an old id or a numeric id was used to find the record, then
-        # the request path will not match the post_path, and we should do
-        # a 301 redirect that uses the current friendly id.
-        if request.path != post_path(@post)
+        # the request slug will not match the current slug, and we should do
+        # a 301 redirect to the new path
+        if params[:id] != @post.slug
           return redirect_to @post, :status => :moved_permanently
         end
       end


### PR DESCRIPTION
The current example code only works correctly for the `#show` action. If the user is using `find_post` for anything other than `#show`, it will re-direct a URL for `#edit` using the new slug to the `#show` for the new slug, making it impossible to edit (or update or destroy)

Note that this will redirect from `/posts/old_slug/edit` to `posts/new_slug`, so from `#edit` to `#show`. The code I implemented actually checks to see if the action_name is 'edit', and if it is, re-direct to the correct edit path. For sake of simplicity, I think it's fine to have the docs re-direct to the `#show`.
