### PR TITLE
Fixed problem that occurred when module :history was used after :finders

### DIFF
--- a/gemfiles/Gemfile.rails-4.0.rb
+++ b/gemfiles/Gemfile.rails-4.0.rb
@@ -17,7 +17,7 @@ group :development, :test do
 
   platforms :ruby, :rbx do
     gem 'sqlite3'
-    gem 'mysql2'
+    gem 'mysql2', '~> 0.3.10'
     gem 'pg'
     gem 'redcarpet'
   end

--- a/gemfiles/Gemfile.rails-4.1.rb
+++ b/gemfiles/Gemfile.rails-4.1.rb
@@ -16,7 +16,7 @@ group :development, :test do
 
   platforms :ruby, :rbx do
     gem 'sqlite3'
-    gem 'mysql2'
+    gem 'mysql2', '~> 0.3.13'
     gem 'pg'
     gem 'redcarpet'
   end

--- a/lib/friendly_id/finders.rb
+++ b/lib/friendly_id/finders.rb
@@ -83,13 +83,10 @@ for models that use FriendlyId with something similar to the following:
 
       # Support for friendly finds on associations for Rails 4.0.1 and above.
       if ::ActiveRecord.const_defined?('AssociationRelation')
+        model_class.extend(ClassMethods)
         association_relation_delegate_class = model_class.relation_delegate_class(::ActiveRecord::AssociationRelation)
         association_relation_delegate_class.send(:include, model_class.friendly_id_config.finder_methods)
       end
-    end
-
-    def self.included(model_class)
-      model_class.extend(ClassMethods)
     end
   end
 end

--- a/lib/friendly_id/finders.rb
+++ b/lib/friendly_id/finders.rb
@@ -80,16 +80,16 @@ for models that use FriendlyId with something similar to the following:
           model_class.send(:extend, friendly_id_config.finder_methods)
         end
       end
-    end
-
-    def self.included(model_class)
-      model_class.extend(ClassMethods)
 
       # Support for friendly finds on associations for Rails 4.0.1 and above.
       if ::ActiveRecord.const_defined?('AssociationRelation')
         association_relation_delegate_class = model_class.relation_delegate_class(::ActiveRecord::AssociationRelation)
         association_relation_delegate_class.send(:include, model_class.friendly_id_config.finder_methods)
       end
+    end
+
+    def self.included(model_class)
+      model_class.extend(ClassMethods)
     end
   end
 end

--- a/lib/friendly_id/history.rb
+++ b/lib/friendly_id/history.rb
@@ -58,12 +58,7 @@ method.
       model_class.instance_eval do
         friendly_id_config.use :slugged
         friendly_id_config.finder_methods = FriendlyId::History::FinderMethods
-        if friendly_id_config.uses? :finders
-          relation.class.send(:include, friendly_id_config.finder_methods)
-          if ActiveRecord::VERSION::MAJOR == 4 && ActiveRecord::VERSION::MINOR == 2
-            model_class.send(:extend, friendly_id_config.finder_methods)
-          end
-        end
+        FriendlyId::Finders.setup(model_class) if friendly_id_config.uses? :finders
       end
     end
 

--- a/test/history_test.rb
+++ b/test/history_test.rb
@@ -217,7 +217,7 @@ class HistoryTestWithFriendlyFinders < HistoryTest
   end
 end
 
-class HistoryTestWithFriendlyFindersModuleBeforeHistory < HistoryTest
+class HistoryTestWithFindersBeforeHistory < HistoryTest
   class Novelist < ActiveRecord::Base
     has_many :novels
   end


### PR DESCRIPTION
Fixed #717.

Module `:finders` includes methods from `friendly_id_config.finder_methods` into base class. But module `:history` replaces this methods. So, to make `:finders` and `:history` works together those methods must be reincluded into base class during initialization of `:history`.