### PR TITLE
Frienldy_id should not generate a slug when all of canidates is nil.

### DIFF
--- a/lib/friendly_id/sequentially_slugged.rb
+++ b/lib/friendly_id/sequentially_slugged.rb
@@ -4,13 +4,11 @@ module FriendlyId
       model_class.friendly_id_config.use :slugged
     end
 
-    def should_generate_new_friendly_id?
-      send(friendly_id_config.base).present? && super
-    end
-
     def resolve_friendly_id_conflict(candidate_slugs)
+      candidate = candidate_slugs.first
+      return if candidate.nil?
       SequentialSlugCalculator.new(scope_for_slug_generator,
-                                  candidate_slugs.first,
+                                  candidate,
                                   friendly_id_config.slug_column,
                                   friendly_id_config.sequence_separator).next_slug
     end

--- a/test/sequentially_slugged_test.rb
+++ b/test/sequentially_slugged_test.rb
@@ -89,6 +89,22 @@ class SequentiallySluggedTest < TestCaseClass
     end
   end
 
+  test "should not generate a slug when canidates set is empty" do
+    model_class = Class.new(ActiveRecord::Base) do
+      self.table_name = "cities"
+      extend FriendlyId
+      friendly_id :slug_candidates, :use => [ :sequentially_slugged ]
+
+      def slug_candidates
+        [name, [name, code]]
+      end
+    end
+    transaction do
+      record = model_class.create!(:name => nil, :code => nil)
+      assert_nil record.slug
+    end
+  end
+
   test "should not generate a slug when the sluggable attribute is blank" do
     record = model_class.create!(:name => '')
     assert_nil record.slug


### PR DESCRIPTION
Previously `friendly_id_config.base` was checked on presence in `should_generate_new_friendly_id?`. And let's imagine that we have multiple slug candidates, but all of them is nil. In this case we will have something like `[nil, nil]` as base for slug and `presence?` for this array will be evalutated to true. But all of slug canidates is nil, right? Booom! Exception during execution of `resolve_friendly_id_conflict`.