### PR TITLE
Moved joins on slugs table from exists_by_friendly_id to scope_for_slug_generator

### DIFF
--- a/lib/friendly_id/history.rb
+++ b/lib/friendly_id/history.rb
@@ -79,7 +79,7 @@ method.
       include ::FriendlyId::FinderMethods
 
       def exists_by_friendly_id?(id)
-        joins(:slugs).where(arel_table[friendly_id_config.query_field].eq(id)).exists? || joins(:slugs).where(slug_history_clause(id)).exists?
+        where(arel_table[friendly_id_config.query_field].eq(id)).exists? || joins(:slugs).where(slug_history_clause(id)).exists?
       end
 
       private
@@ -106,7 +106,7 @@ method.
     def scope_for_slug_generator
       relation = super
       return relation if new_record?
-      relation = relation.merge(Slug.where('sluggable_id <> ?', id))
+      relation = relation.joins(:slugs).merge(Slug.where('sluggable_id <> ?', id))
       if friendly_id_config.uses?(:scoped)
         relation = relation.where(Slug.arel_table[:scope].eq(serialized_scope))
       end


### PR DESCRIPTION
Call of `joins(:slugs)` in `FriendlyId::History#exists_by_friendly_id?` was expected by `FriendlyId::History#scope_for_slug_generator`, but it was useless for `exists_by_friendly_id?` itself and led to additional INNER JOIN in query without any reason. So, it was moved.