### PR TITLE
Conditionally turn off :dependent => :destory on FriendlyId::Slugs 

### DIFF
--- a/lib/friendly_id/base.rb
+++ b/lib/friendly_id/base.rb
@@ -187,9 +187,15 @@ often better and easier to use {FriendlyId::Slugged slugs}.
     #   allows an alternate configuration syntax, and conditional configuration
     #   logic.
     #
+    # @option options [Symbol,Boolean] :dependent Available when using `:history`.
+    #   Sets the value used for the slugged association's dependent option. Use
+    #   `false` if you do not want to dependently destroy the associated slugged
+    #   record. Defaults to `:destroy`.
+    #
     # @yieldparam config The model class's {FriendlyId::Configuration friendly_id_config}.
     def friendly_id(base = nil, options = {}, &block)
       yield friendly_id_config if block_given?
+      friendly_id_config.dependent = options.delete :dependent
       friendly_id_config.use options.delete :use
       friendly_id_config.send :set, base ? options.merge(:base => base) : options
       include Model

--- a/lib/friendly_id/configuration.rb
+++ b/lib/friendly_id/configuration.rb
@@ -18,6 +18,9 @@ module FriendlyId
     # The module to use for finders
     attr_accessor :finder_methods
 
+    # The value used for the slugged association's dependent option
+    attr_accessor :dependent
+
     def initialize(model_class, values = nil)
       @model_class    = model_class
       @defaults       = {}

--- a/lib/friendly_id/history.rb
+++ b/lib/friendly_id/history.rb
@@ -54,9 +54,16 @@ method.
 =end
   module History
 
+    module Configuration
+      def dependent_value
+        dependent.nil? ? :destroy : dependent
+      end
+    end
+
     def self.setup(model_class)
       model_class.instance_eval do
         friendly_id_config.use :slugged
+        friendly_id_config.class.send :include, History::Configuration
         friendly_id_config.finder_methods = FriendlyId::History::FinderMethods
         if friendly_id_config.uses? :finders
           relation.class.send(:include, friendly_id_config.finder_methods)
@@ -72,7 +79,7 @@ method.
       model_class.class_eval do
         has_many :slugs, -> {order("#{Slug.quoted_table_name}.id DESC")}, {
           :as         => :sluggable,
-          :dependent  => :destroy,
+          :dependent  => @friendly_id_config.dependent_value,
           :class_name => Slug.to_s
         }
 


### PR DESCRIPTION
Hey guys!

This adds the ability not to delete historic slugs when the sluggable class is destroyed.

When using acts_as_paranoid on a sluggable models, we aren't actually deleting the models when calling destroy. If we delete the slugs, we’re losing the history. We're also setting up a condition where a unique constraint ends up getting violated.

This is a revival of https://github.com/norman/friendly_id/pull/268