### PR TITLE
Mixed FriendlyId::UnfriendlyUtils to all classes that are listed in FriendlyId::UNFRIENDLY_CLASSES.

### DIFF
--- a/lib/friendly_id.rb
+++ b/lib/friendly_id.rb
@@ -51,19 +51,6 @@ module FriendlyId
   autoload :Finders,             "friendly_id/finders"
   autoload :SequentiallySlugged, "friendly_id/sequentially_slugged"
 
-  # Instances of these classes will never be considered a friendly id.
-  # @see FriendlyId::ObjectUtils#friendly_id
-  UNFRIENDLY_CLASSES = [
-    ActiveRecord::Base,
-    Array,
-    FalseClass,
-    Hash,
-    NilClass,
-    Numeric,
-    Symbol,
-    TrueClass
-  ]
-
   # FriendlyId takes advantage of `extended` to do basic model setup, primarily
   # extending {FriendlyId::Base} to add {FriendlyId::Base#friendly_id
   # friendly_id} as a class method.

--- a/lib/friendly_id/object_utils.rb
+++ b/lib/friendly_id/object_utils.rb
@@ -40,13 +40,7 @@ module FriendlyId
     #     "123".friendly_id?                #=> nil
     #     "abc123".friendly_id?             #=> true
     def friendly_id?
-      # Considered unfriendly if this is an instance of an unfriendly class or
-      # one of its descendants.
-      if FriendlyId::UNFRIENDLY_CLASSES.detect {|klass| self.class <= klass}
-        false
-      elsif respond_to?(:to_i) && to_i.to_s != to_s
-        true
-      end
+      true if respond_to?(:to_i) && to_i.to_s != to_s
     end
 
     # True if the id is definitely unfriendly, false if definitely friendly,
@@ -55,6 +49,21 @@ module FriendlyId
       val = friendly_id? ; !val unless val.nil?
     end
   end
+
+  module UnfriendlyUtils
+    def friendly_id?
+      false
+    end
+
+    def unfriendly_id?
+      true
+    end
+  end
 end
 
 Object.send :include, FriendlyId::ObjectUtils
+
+# Considered unfriendly if object is an instance of an unfriendly class or
+# one of its descendants.
+
+FriendlyId::UNFRIENDLY_CLASSES.each { |klass| klass.send(:include, FriendlyId::UnfriendlyUtils) }

--- a/lib/friendly_id/object_utils.rb
+++ b/lib/friendly_id/object_utils.rb
@@ -1,4 +1,17 @@
 module FriendlyId
+  # Instances of these classes will never be considered a friendly id.
+  # @see FriendlyId::ObjectUtils#friendly_id
+  UNFRIENDLY_CLASSES = [
+    ActiveRecord::Base,
+    Array,
+    FalseClass,
+    Hash,
+    NilClass,
+    Numeric,
+    Symbol,
+    TrueClass
+  ]
+
   # Utility methods for determining whether any object is a friendly id.
   #
   # Monkey-patching Object is a somewhat extreme measure not to be taken lightly


### PR DESCRIPTION
Simplified PR #674 as was discussed in it's conversation.

If we know that class is "unfriendly" because it's included in our list of such classes we can just return appropriate true / false from re-implemented friendly_id? / unfriendly_id? instead of searching through FriendlyId::UNFRIENDLY_CLASSES each time when those methods are called.