### PR TITLE
Feature/rails 5 finders

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,13 @@ matrix:
     - rvm: jruby-19mode
       gemfile: gemfiles/Gemfile.rails-4.2.rb
       env: DB=postgres
+  exclude:
+    - rvm: 2.0.0
+      gemfile: gemfiles/Gemfile.rails-5.0.rb
+    - rvm: 2.1.0
+      gemfile: gemfiles/Gemfile.rails-5.0.rb
+    - rvm: 2.2.0
+      gemfile: gemfiles/Gemfile.rails-5.0.rb
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ matrix:
     - rvm: jruby-19mode
       gemfile: gemfiles/Gemfile.rails-4.2.rb
       env: DB=postgres
+    - rvm: jruby-9.0.4.0
+      gemfile: gemfiles/Gemfile.rails-5.0.rb
   exclude:
     - rvm: 2.0.0
       gemfile: gemfiles/Gemfile.rails-5.0.rb

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ gemfile:
   - gemfiles/Gemfile.rails-4.0.rb
   - gemfiles/Gemfile.rails-4.1.rb
   - gemfiles/Gemfile.rails-4.2.rb
+  - gemfiles/Gemfile.rails-5.0.rb
 
 matrix:
   allow_failures:

--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,7 @@ suggestions, ideas and improvements to FriendlyId.
 * Don't set or change slug when unrelated validation failures block the record from being saved ([#642](https://github.com/norman/friendly_id/issues/642)).
 * Fix order dependence bug between history and finders modules ([#718](https://github.com/norman/friendly_id/pull/718))
 * Added ability to conditionally turn off :dependent => :destory on FriendlyId::Slugs([#724](https://github.com/norman/friendly_id/pull/724))
+* Add support for Rails 5. ([#728](https://github.com/norman/friendly_id/pull/728))
 
 ## 5.1.0 (2015-01-15)
 

--- a/gemfiles/Gemfile.rails-5.0.rb
+++ b/gemfiles/Gemfile.rails-5.0.rb
@@ -1,0 +1,28 @@
+source 'https://rubygems.org'
+
+gemspec path: '../'
+
+gem 'activerecord', '~> 5.0.0.beta2'
+gem 'railties', '~> 5.0.0.beta2'
+gem 'i18n', '~> 0.7.0'
+
+# Database Configuration
+group :development, :test do
+  platforms :jruby do
+    gem 'activerecord-jdbcmysql-adapter', '~> 1.3.14'
+    gem 'activerecord-jdbcpostgresql-adapter', '~> 1.3.14'
+    gem 'kramdown'
+  end
+
+  platforms :ruby, :rbx do
+    gem 'sqlite3'
+    gem 'mysql2'
+    gem 'pg'
+    gem 'redcarpet'
+  end
+
+  platforms :rbx do
+    gem 'rubysl', '~> 2.0'
+    gem 'rubinius-developer_tools'
+  end
+end

--- a/lib/friendly_id/finders.rb
+++ b/lib/friendly_id/finders.rb
@@ -76,7 +76,7 @@ for models that use FriendlyId with something similar to the following:
     def self.setup(model_class)
       model_class.instance_eval do
         relation.class.send(:include, friendly_id_config.finder_methods)
-        if ActiveRecord::VERSION::MAJOR == 4 && ActiveRecord::VERSION::MINOR == 2
+        if (ActiveRecord::VERSION::MAJOR == 4 && ActiveRecord::VERSION::MINOR == 2) || ActiveRecord::VERSION::MAJOR == 5
           model_class.send(:extend, friendly_id_config.finder_methods)
         end
       end


### PR DESCRIPTION
I'm running a rails app using 5.0.0.beta1. I noticed finders weren't getting added to models.

There's currently a check against the rails major+minor version to only include finders using `extend` if the version is 4.2. This changes also allows a major version of 5. 

Added a gemfile to run the tests against rails 5.