### PR TITLE
filter out false positive conflict records in sequentially_slugged

### DIFF
--- a/lib/friendly_id/sequentially_slugged.rb
+++ b/lib/friendly_id/sequentially_slugged.rb
@@ -40,9 +40,12 @@ module FriendlyId
       end
 
       def slug_conflicts
-        scope.
-          where(conflict_query, slug, sequential_slug_matcher).
-          order(ordering_query).pluck(slug_column)
+        conflicts = scope.
+                      where(conflict_query, slug, sequential_slug_matcher).
+                      order(ordering_query).pluck(slug_column)
+
+        # ensures that all conflicts contain the slug, separator, and number
+        conflicts.select { |conflict| /#{slug}#{sequence_separator}\d/.match(conflict) }
       end
 
       def conflict_query
@@ -70,3 +73,4 @@ module FriendlyId
     end
   end
 end
+

--- a/test/sequentially_slugged_test.rb
+++ b/test/sequentially_slugged_test.rb
@@ -39,6 +39,22 @@ class SequentiallySluggedTest < TestCaseClass
     end
   end
 
+  test "should cope with additional conflict records due to slug being a substring" do
+    transaction do
+      record_0 = model_class.create!(:name => 'A thing that is a thing')
+      record_1 = model_class.create!(:name => 'A thing')
+      record_2 = model_class.create!(:name => 'A thing')
+
+      assert_equal 'a-thing-that-is-a-thing', record_0.slug
+      assert_equal 'a-thing', record_1.slug
+      assert_equal 'a-thing-2', record_2.slug
+
+      record_3 = model_class.create!(:name => 'A thing')
+
+      assert_equal 'a-thing-3', record_3.slug
+    end
+  end
+
   test "should cope with strange column names" do
     model_class = Class.new(ActiveRecord::Base) do
       self.table_name = "journalists"
@@ -89,7 +105,7 @@ class SequentiallySluggedTest < TestCaseClass
     end
   end
 
-  test "should not generate a slug when canidates set is empty" do
+  test "should not generate a slug when candidates set is empty" do
     model_class = Class.new(ActiveRecord::Base) do
       self.table_name = "cities"
       extend FriendlyId
@@ -110,3 +126,4 @@ class SequentiallySluggedTest < TestCaseClass
     assert_nil record.slug
   end
 end
+


### PR DESCRIPTION
The SQL query to return conflicts is picking up additional records where the slug is a substring of a longer slug.  For example, the slug "a-string" will return conflicts matching "a-string-1" and "a-string-foo".  This was causing ActiveRecord::RecordNotUnique errors.

Rather than implement cross-database regex, this pull request filters out the false positive conflicts after the results are returned.
