### PR TITLE
Fixes #743 - skips different slugs with the same stem

### DIFF
--- a/lib/friendly_id/sequentially_slugged.rb
+++ b/lib/friendly_id/sequentially_slugged.rb
@@ -34,9 +34,10 @@ module FriendlyId
       end
 
       def last_sequence_number
-        if match = /#{slug}#{sequence_separator}(\d+)\z/.match(slug_conflicts.last)
-          match[1].to_i
-        end
+        regex = /#{slug}#{sequence_separator}(\d+)\z/
+        slug_conflicts.map { |slug_conflict|
+          regex.match(slug_conflict).to_a.last
+        }.compact.last.try(:to_i)
       end
 
       def slug_conflicts

--- a/test/sequentially_slugged_test.rb
+++ b/test/sequentially_slugged_test.rb
@@ -109,4 +109,18 @@ class SequentiallySluggedTest < TestCaseClass
     record = model_class.create!(:name => '')
     assert_nil record.slug
   end
+
+  test "should skip slugs which are different but share same stem" do
+    transaction do
+      record_1 = model_class.create!(:name => 'A thing')
+      record_2 = model_class.create!(:name => 'A thing')
+      record_3 = model_class.create!(:name => 'A thing test')
+      record_4 = model_class.create!(:name => 'A thing')
+
+      assert_equal 'a-thing', record_1.slug
+      assert_equal 'a-thing-2', record_2.slug
+      assert_equal 'a-thing-test', record_3.slug
+      assert_equal 'a-thing-3', record_4.slug
+    end
+  end
 end


### PR DESCRIPTION
When calculating the next id for sequentially slugged attributes it used to
take slug into account which had the same stem for example 'a-ting', 'a-thing-2' and
'a-thing-test'. It didn't ignore 'a-thing-test' and therefore caluclated 2 and
not 3 as the next id.
