### PR TITLE
Fix SequentiallySlugged when used with History

### DIFF
--- a/lib/friendly_id/sequentially_slugged.rb
+++ b/lib/friendly_id/sequentially_slugged.rb
@@ -10,16 +10,18 @@ module FriendlyId
       SequentialSlugCalculator.new(scope_for_slug_generator,
                                   candidate,
                                   friendly_id_config.slug_column,
-                                  friendly_id_config.sequence_separator).next_slug
+                                  friendly_id_config.sequence_separator,
+                                  self.class.base_class).next_slug
     end
 
     class SequentialSlugCalculator
       attr_accessor :scope, :slug, :slug_column, :sequence_separator
 
-      def initialize(scope, slug, slug_column, sequence_separator)
+      def initialize(scope, slug, slug_column, sequence_separator, base_class)
         @scope = scope
         @slug = slug
-        @slug_column = scope.connection.quote_column_name(slug_column)
+        table_name = scope.connection.quote_table_name(base_class.arel_table.name)
+        @slug_column = "#{table_name}.#{scope.connection.quote_column_name(slug_column)}"
         @sequence_separator = sequence_separator
       end
 

--- a/test/sequentially_slugged_test.rb
+++ b/test/sequentially_slugged_test.rb
@@ -110,3 +110,31 @@ class SequentiallySluggedTest < TestCaseClass
     assert_nil record.slug
   end
 end
+
+class SequentiallySluggedTestWithHistory < TestCaseClass
+  include FriendlyId::Test
+  include FriendlyId::Test::Shared::Core
+
+  class Article < ActiveRecord::Base
+    extend FriendlyId
+    friendly_id :name, :use => [:sequentially_slugged, :history]
+  end
+
+  def model_class
+    Article
+  end
+
+  test "should work with regeneration with history when slug already exists" do
+    transaction do
+      record1 = model_class.create! :name => "Test name"
+      record2 = model_class.create! :name => "Another test name"
+      assert_equal 'test-name', record1.slug
+      assert_equal 'another-test-name', record2.slug
+
+      record2.name = "Test name"
+      record2.slug = nil
+      record2.save!
+      assert_equal 'test-name-2', record2.slug
+    end
+  end
+end


### PR DESCRIPTION
I encountered a crash when using `:sequentially-slugged` with `:history`. Since it does a join with the history table, it causes an ambiguous column name error:

```
ActiveRecord::StatementInvalid: SQLite3::SQLException: ambiguous column name: slug: SELECT "slug" FROM "articles" INNER JOIN "friendly_id_slugs" ON "friendly_id_slugs"."sluggable_id" = "articles"."id" AND "friendly_id_slugs"."sluggable_type" = ? WHERE ("articles"."id" != 3) AND (sluggable_id <> 3) AND ("slug" = 'test-name' OR "slug" LIKE 'test-name-%' ESCAPE '\')  ORDER BY LENGTH("slug") ASC, "slug" ASC
```

This fix adds disambiguation to `:sequentially-slugged` by including the table name whereever it uses a column name.
