### PR TITLE
Update rails-5 gem with activerecord/railties 5.0.0

### DIFF
--- a/gemfiles/Gemfile.rails-5.0.rb
+++ b/gemfiles/Gemfile.rails-5.0.rb
@@ -2,8 +2,8 @@ source 'https://rubygems.org'
 
 gemspec path: '../'
 
-gem 'activerecord', '~> 5.0.0.beta2'
-gem 'railties', '~> 5.0.0.beta2'
+gem 'activerecord', '~> 5.0.0'
+gem 'railties', '~> 5.0.0'
 gem 'i18n', '~> 0.7.0'
 
 # Database Configuration


### PR DESCRIPTION
I've been using friendly_id along with rails5-rc since it was released with no issues. 

Updating the rails-5 gem to use rc1. 

@djsegal was enquiring about the stability of rc1 here: https://github.com/norman/friendly_id/pull/753  - figured it would make sense to update the specs to use the latest version.