### PR TITLE
Ability to change slugs manually

### DIFF
--- a/lib/friendly_id/sequentially_slugged.rb
+++ b/lib/friendly_id/sequentially_slugged.rb
@@ -7,9 +7,10 @@ module FriendlyId
     def resolve_friendly_id_conflict(candidate_slugs)
       candidate = candidate_slugs.first
       return if candidate.nil?
+      column_table = self.class.table_name
       SequentialSlugCalculator.new(scope_for_slug_generator,
                                   candidate,
-                                  friendly_id_config.slug_column,
+                                  "#{column_table}.#{friendly_id_config.slug_column}",
                                   friendly_id_config.sequence_separator).next_slug
     end
 
@@ -19,7 +20,7 @@ module FriendlyId
       def initialize(scope, slug, slug_column, sequence_separator)
         @scope = scope
         @slug = slug
-        @slug_column = scope.connection.quote_column_name(slug_column)
+        @slug_column = slug_column #scope.connection.quote_column_name(slug_column)
         @sequence_separator = sequence_separator
       end
 

--- a/lib/friendly_id/version.rb
+++ b/lib/friendly_id/version.rb
@@ -1,3 +1,3 @@
 module FriendlyId
-  VERSION = "5.2.0.beta.1"
+  VERSION = "5.2.0.beta.2"
 end

--- a/lib/friendly_id/version.rb
+++ b/lib/friendly_id/version.rb
@@ -1,3 +1,3 @@
 module FriendlyId
-  VERSION = "5.2.0.beta.2"
+  VERSION = "5.2.0.beta.1"
 end

--- a/test/manually_change_slug_test.rb
+++ b/test/manually_change_slug_test.rb
@@ -1,0 +1,63 @@
+require 'helper'
+
+class Article < ActiveRecord::Base
+  extend FriendlyId
+
+  friendly_id :name, use: [:sequentially_slugged, :history]
+
+  protected
+
+  def should_generate_new_friendly_id?
+    slug.blank?
+  end
+
+  def should_manually_change_friendly_id?
+    slug_changed?
+  end
+end
+
+class ManuallyChangeSlugTest < TestCaseClass
+  include FriendlyId::Test
+  include FriendlyId::Test::Shared::Core
+
+  def model_class
+    Article
+  end
+
+  test "should generate slug when it is blank" do
+    transaction do
+      record1 = model_class.create(name: 'Some cool article')
+
+      assert_equal 'some-cool-article', record1.slug
+    end
+  end
+
+  test "should not generate slug when it is already exists" do
+    transaction do
+      record1 = model_class.create(name: 'Some cool article')
+
+      assert_equal 'some-cool-article', record1.slug
+
+      record1.update_attributes(name: 'Another news')
+
+      assert_equal 'some-cool-article', record1.slug
+    end
+  end
+
+  test "should be able to change slug manually considering history" do
+    transaction do
+      record1 = model_class.create(name: 'About us')
+      assert_equal 'about-us', record1.slug
+
+      record1.update_attributes(slug: 'something-about-us')
+      assert_equal 'something-about-us', record1.slug
+      assert_equal record1.slugs.count, 2
+
+      record2 = model_class.create(name: 'Yes, you win!')
+      assert_equal 'yes-you-win', record2.slug
+
+      record2.update_attributes(slug: 'about-us')
+      assert_equal 'about-us-2', record2.slug
+    end
+  end
+end


### PR DESCRIPTION
**What have done:**
1. Implemented processing use case when slug can be changed manually. For example, by content manager in the admin panel.
2. Added specs for new use case.

**The main point of this pull request**

By additional possibility for configuration (I mean override `#should_manually_change_friendly_id?` and `#should_generate_new_friendly_id?`) you can setup the next flow of changing slugs:
1. When sluggable object is created a slug is automatically generated based on a some field value.
2. When source field for the slug is changed the slug stays same.
3. In order to change slug there is an admin panel and content manager is able to change it. That new slug is checked with current sluggable objects slugs and with the history slugs, and can be prepended with the counter if this is needed. Eventually the final version of the slug also is added to the history.

The described above flow I was asked to implement in the one of your projects. Maybe it will be useful for someone.
