### PR TITLE
Require active record before using it

### DIFF
--- a/lib/friendly_id.rb
+++ b/lib/friendly_id.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+require 'active_record'
 require "friendly_id/base"
 require "friendly_id/object_utils"
 require "friendly_id/configuration"


### PR DESCRIPTION
Trying to require friendly_id outside of rails results in `uninitialized constant FriendlyId::ActiveRecord`.  My use case is preloading gems with sidekiq swarm.

Adding a require fixes this use case.
