### PR TITLE
Assign to configured slug column, not "slug", when validation fails

### DIFF
--- a/lib/friendly_id/slugged.rb
+++ b/lib/friendly_id/slugged.rb
@@ -327,9 +327,9 @@ Github issue](https://github.com/norman/friendly_id/issues/185) for discussion.
     private :slug_generator
 
     def unset_slug_if_invalid
-      if errors.present? && attribute_changed?(friendly_id_config.query_field)
+      if errors.present? && attribute_changed?(friendly_id_config.query_field.to_s)
         diff = changes[friendly_id_config.query_field]
-        self.slug = diff.first
+        send "#{friendly_id_config.slug_column}=", diff.first
       end
     end
     private :unset_slug_if_invalid

--- a/test/schema.rb
+++ b/test/schema.rb
@@ -67,6 +67,9 @@ module FriendlyId
           # Used to test candidates
           add_column :cities, :code, :string, :limit => 3
 
+          # Used as a non-default slug_column
+          add_column :authors, :subdomain, :string
+
           @done = true
         end
 

--- a/test/slugged_test.rb
+++ b/test/slugged_test.rb
@@ -110,6 +110,26 @@ class SluggedTest < TestCaseClass
     end
   end
 
+  test "should not set slug on create if unrelated validations fail with custom slug_column" do
+    klass = Class.new(ActiveRecord::Base) do
+      self.table_name = 'authors'
+      extend FriendlyId
+      validates_presence_of :active
+      friendly_id :name, :use => :slugged, :slug_column => :subdomain
+
+      def self.name
+        "Author"
+      end
+    end
+
+    transaction do
+      instance = klass.new :name => 'foo'
+      refute instance.save
+      refute instance.valid?
+      assert_nil instance.subdomain
+    end
+  end
+
   test "should not update slug on save if unrelated validations fail" do
     klass = Class.new model_class do
       validates_presence_of :active


### PR DESCRIPTION
1f8af74b mistakenly assigns to the literal `slug` method, rather than the configured `slug_column`. As a result, models using a custom `slug_column` get an error raised when validations fail that `slug=` is an undefined method.

Fixes #765.