### PR TITLE
Change ActiveRecord::Base to ApplicationRecord

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ rake db:migrate
 ```
 ```ruby
 # edit app/models/user.rb
-class User < ActiveRecord::Base
+class User < ApplicationRecord
   extend FriendlyId
   friendly_id :name, use: :slugged
 end


### PR DESCRIPTION
Rails 5 Active Record models now inherit from `ApplicationRecord` by default. I thought it appropriate to reflect this in the readme. 