### PR TITLE
Case Insensitivity for `id`, fixes #785

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,7 +5,7 @@ suggestions, ideas and improvements to FriendlyId.
 
 ## Unreleased
 
-Make `first_by_friendly_id` use case insensitive slug search using `downcase`. ([#787](https://github.com/norman/friendly_id/pull/787))
+* Make `first_by_friendly_id` case insensitive using `downcase`. ([#787](https://github.com/norman/friendly_id/pull/787))
 
 ## 5.2.0 (2016-12-01)
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,10 @@
 We would like to think our many [contributors](https://github.com/norman/friendly_id/graphs/contributors) for
 suggestions, ideas and improvements to FriendlyId.
 
+## Unreleased
+
+Make `first_by_friendly_id` use case insensitive slug search using `downcase`. ([#787](https://github.com/norman/friendly_id/pull/787))
+
 ## 5.2.0 (2016-12-01)
 
 * Add sequential slug module for FriendlyId 4.x-style sequential slugs. ([#644](https://github.com/norman/friendly_id/pull/644)).

--- a/lib/friendly_id/finder_methods.rb
+++ b/lib/friendly_id/finder_methods.rb
@@ -54,7 +54,7 @@ module FriendlyId
     end
 
     def first_by_friendly_id(id)
-      find_by(friendly_id_config.query_field => id)
+      find_by(friendly_id_config.query_field => id.downcase)
     end
 
   end

--- a/test/finders_test.rb
+++ b/test/finders_test.rb
@@ -26,4 +26,28 @@ class Finders < TestCaseClass
       assert model_class.existing.find(record.friendly_id)
     end
   end
+
+  test 'should find capitalized records with finders as class methods' do
+    with_instance_of(model_class) do |record|
+      assert model_class.find(record.friendly_id.capitalize)
+    end
+  end
+
+  test 'should find capitalized records with finders on relations' do
+    with_instance_of(model_class) do |record|
+      assert model_class.existing.find(record.friendly_id.capitalize)
+    end
+  end
+
+  test 'should find upcased records with finders as class methods' do
+    with_instance_of(model_class) do |record|
+      assert model_class.find(record.friendly_id.upcase)
+    end
+  end
+
+  test 'should find upcased records with finders on relations' do
+    with_instance_of(model_class) do |record|
+      assert model_class.existing.find(record.friendly_id.upcase)
+    end
+  end
 end


### PR DESCRIPTION
Hello. This PR is about fixing the first issue of #785 by using `id.downcase` instead of `id` in `first_by_friendly_id` method. In this way if the url is like `users/John-Doe` or `users/JOHN-DOE`, it will search by `john-doe` in database.

Currently, it `find_by` with `id`.(case-sensitive)
```ruby
# finder_methods.rb

def first_by_friendly_id(id)
	# If `id` is "John-Doe" or "JOHN-DOE"
	find_by(friendly_id_config.query_field => id)
	# It raises `ActiveRecord::RecordNotFound`.
end
```

It `find_by` with id.downcase.(case-insensitive)
```ruby
# finder_methods.rb

def first_by_friendly_id(id)
	# If `id` is "John-Doe" or "JOHN-DOE"
	find_by(friendly_id_config.query_field => id.downcase)
	# It finds data by "john-doe".
end
```
The tests for the change have been added and all have passed.