### PR TITLE
Predictive Match for `id`, Fix #785

### DIFF
--- a/lib/friendly_id/finder_methods.rb
+++ b/lib/friendly_id/finder_methods.rb
@@ -33,7 +33,7 @@ module FriendlyId
     # `find`.
     # @raise ActiveRecord::RecordNotFound
     def find_by_friendly_id(id)
-      first_by_friendly_id(id) or raise ActiveRecord::RecordNotFound, "can't find record with friendly id: #{id.inspect}"
+      first_by_friendly_id(id) or raise ActiveRecord::RecordNotFound, "can't find record with friendly id: #{id.inspect}#{similar_id(id)}"
     end
 
     def exists_by_friendly_id?(id)

--- a/lib/friendly_id/finder_methods.rb
+++ b/lib/friendly_id/finder_methods.rb
@@ -20,7 +20,7 @@ module FriendlyId
       return super if args.count != 1 || id.unfriendly_id?
       first_by_friendly_id(id).tap {|result| return result unless result.nil?}
       return super if potential_primary_key?(id)
-      raise ActiveRecord::RecordNotFound, "can't find record with friendly id: #{id.inspect}"
+      raise ActiveRecord::RecordNotFound, "can't find record with friendly id: #{id.inspect}#{similar_id(id)}"
     end
 
     # Returns true if a record with the given id exists.
@@ -55,6 +55,15 @@ module FriendlyId
 
     def first_by_friendly_id(id)
       find_by(friendly_id_config.query_field => id)
+    end
+
+    def similar_id(id)
+      slug_column = friendly_id_config.query_field
+      results = where("#{slug_column} LIKE '%#{id}%'")
+      if results.any?
+        results_str = results.map {|result| result[slug_column].inspect }.join(', ')
+        return "\nDo you mean? #{results_str}"
+      end
     end
 
   end


### PR DESCRIPTION
Hello. This PR is about fixing the second issue of #785 by printing the similar ids with the `RecordNotFound` error message.

The current `RecordNotFound` error message is:
```bash
ActiveRecord::RecordNotFound (can't find record with friendly id: "john"):
```
The new `RecordNotFound` error message with predictive match for `id` is:
```bash
ActiveRecord::RecordNotFound (can't find record with friendly id: "john"
Do you mean? "john-doe", "john-smith"):
```
