### PR TITLE
Add :finders module to documentation comment

### DIFF
--- a/lib/friendly_id/base.rb
+++ b/lib/friendly_id/base.rb
@@ -159,8 +159,9 @@ often better and easier to use {FriendlyId::Slugged slugs}.
     #
     # @option options [Symbol,Module] :use The addon or name of an addon to use.
     #   By default, FriendlyId provides {FriendlyId::Slugged :slugged},
-    #   {FriendlyId::History :history}, {FriendlyId::Reserved :reserved}, and
-    #   {FriendlyId::Scoped :scoped}, and {FriendlyId::SimpleI18n :simple_i18n}.
+    #   {FriendlyId::Reserved :finders}, {FriendlyId::History :history},
+    #   {FriendlyId::Reserved :reserved}, {FriendlyId::Scoped :scoped}, and
+    #   {FriendlyId::SimpleI18n :simple_i18n}.
     #
     # @option options [Array] :reserved_words Available when using `:reserved`,
     #   which is loaded by default. Sets an array of words banned for use as

--- a/lib/friendly_id/configuration.rb
+++ b/lib/friendly_id/configuration.rb
@@ -47,8 +47,8 @@ module FriendlyId
     #
     # @param [#to_s,Module] modules Arguments should be Modules, or symbols or
     #   strings that correspond with the name of an addon to use with FriendlyId.
-    #   By default FriendlyId provides `:slugged`, `:history`, `:simple_i18n`,
-    #   and `:scoped`.
+    #   By default FriendlyId provides `:slugged`, `:finders`, `:history`,
+    #   `:reserved`, `:simple_i18n`, and `:scoped`.
     def use(*modules)
       modules.to_a.flatten.compact.map do |object|
         mod = get_module(object)


### PR DESCRIPTION
Not sure if all these are still there, but `finders` was missing