### PR TITLE
BUG? Add test that replays upgrading to history module

### DIFF
--- a/test/candidates_test.rb
+++ b/test/candidates_test.rb
@@ -140,4 +140,27 @@ class CandidatesTest < TestCaseClass
     end
   end
 
+  test "should not fail when adding history to existing" do
+    name_collision = "Amsterdam"
+
+    with_instances do |city1, _|
+      assert city1.update name: name_collision, slug: nil
+      assert_equal name_collision.downcase, city1.slug
+
+      klass = Class.new city1.class do
+        friendly_id_config.model_class = city1.class
+        friendly_id_config.use(:history)
+
+        def slug_candidates
+          [:name, [:name, "-alt"]]
+        end
+      end
+      assert klass.friendly_id_config.uses? :history
+
+      city2 = klass.last
+
+      assert city2.update name: name_collision, slug: nil
+      assert_equal "#{name_collision.downcase}-alt", city2.slug
+    end
+  end
 end


### PR DESCRIPTION
I've been using FriendlyId for our projects in the last couple of years and it has been working out pretty well. Until recently, that is, when we decided to extend our models using FriendlyId with the :history module. Apart from introducing the `friendly_id_slugs` table, we didn't write any migrations or tasks migrating our data. As a result we got `PG::UniqueViolation`s. The introduced test showcases the issues.

Do you guys consider this a bug? I am willing to work on a fix...

Thx for the effort you put into maintaining this!