### PR TITLE
Update dirty tracking code for Rails 5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ gemfile:
   - gemfiles/Gemfile.rails-4.1.rb
   - gemfiles/Gemfile.rails-4.2.rb
   - gemfiles/Gemfile.rails-5.0.rb
+  - gemfiles/Gemfile.rails-5.1.rb
 
 matrix:
   allow_failures:

--- a/gemfiles/Gemfile.rails-5.1.rb
+++ b/gemfiles/Gemfile.rails-5.1.rb
@@ -1,0 +1,28 @@
+source 'https://rubygems.org'
+
+gemspec path: '../'
+
+gem 'activerecord', '~> 5.1.0'
+gem 'railties', '~> 5.1.0'
+gem 'i18n', '~> 0.7.0'
+
+# Database Configuration
+group :development, :test do
+  platforms :jruby do
+    gem 'activerecord-jdbcmysql-adapter', '~> 1.3.14'
+    gem 'activerecord-jdbcpostgresql-adapter', '~> 1.3.14'
+    gem 'kramdown'
+  end
+
+  platforms :ruby, :rbx do
+    gem 'sqlite3'
+    gem 'mysql2'
+    gem 'pg'
+    gem 'redcarpet'
+  end
+
+  platforms :rbx do
+    gem 'rubysl', '~> 2.0'
+    gem 'rubinius-developer_tools'
+  end
+end

--- a/lib/friendly_id/migration.rb
+++ b/lib/friendly_id/migration.rb
@@ -1,4 +1,10 @@
-class CreateFriendlyIdSlugs < ActiveRecord::Migration
+migration_superclass = if ActiveRecord::VERSION::MAJOR >= 5
+  ActiveRecord::Migration["#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}"]
+else
+  ActiveRecord::Migration
+end
+
+class CreateFriendlyIdSlugs < migration_superclass
   def change
     create_table :friendly_id_slugs do |t|
       t.string   :slug,           :null => false

--- a/test/schema.rb
+++ b/test/schema.rb
@@ -2,7 +2,13 @@ require "friendly_id/migration"
 
 module FriendlyId
   module Test
-    class Schema < ActiveRecord::Migration
+    migration_superclass = if ActiveRecord::VERSION::MAJOR >= 5
+      ActiveRecord::Migration["#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}"]
+    else
+      ActiveRecord::Migration
+    end
+
+    class Schema < migration_superclass
       class << self
         def down
           CreateFriendlyIdSlugs.down

--- a/test/shared.rb
+++ b/test/shared.rb
@@ -64,7 +64,7 @@ module FriendlyId
           with_instance_of my_model_class do |record|
             record.update_attributes my_model_class.friendly_id_config.slug_column => nil
             record = my_model_class.friendly.find(record.id)
-            record.class.validate Proc.new {errors[:name] = "FAIL"}
+            record.class.validate Proc.new {errors.add(:name, "FAIL")}
             record.save
             assert_equal record.to_param, record.friendly_id
           end


### PR DESCRIPTION
We get deprecation warnings if we call `attribute_changed?` or `changes` now; this change uses the alternatives suggested by the deprecation warnings.