### PR TITLE
How to: Prevent warning on db:migrate in Rails 5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,11 @@ gem 'friendly_id', '~> 5.1.0' # Note: You MUST use 5.0.0 or greater for Rails 4.
 ```
 ```shell
 rails generate friendly_id
+```
+>Temp solution for Rails 5.1+ : Before running the migration, go into the generated migration file and specify the Rails version:  
+`class CreateFriendlyIdSlugs < ActiveRecord::Migration[5.1]`  
+```
+```shell
 rails generate scaffold user name:string slug:string:uniq
 rake db:migrate
 ```


### PR DESCRIPTION
Related issue #817 
To be solved with #816 (Update for Rails 5.1)

Added a few lines to the Readme how to prevent the warning that appears when running db:migrate on the  generated migration.
No big deal, but it speeds things up a bit for dev happiness 🎁 
  