### PR TITLE
Remove extra ``` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,6 @@ rails generate friendly_id
 ```
 >Temp solution for Rails 5.1+ : Before running the migration, go into the generated migration file and specify the Rails version:  
 `class CreateFriendlyIdSlugs < ActiveRecord::Migration[5.1]`  
-```
 ```shell
 rails generate scaffold user name:string slug:string:uniq
 rake db:migrate


### PR DESCRIPTION
There was an extra set of backticks in the README, so **```shell** was showing up in the code block.