### PR TITLE
option to treat reserved words as conflicts, fix #830

### DIFF
--- a/lib/friendly_id/reserved.rb
+++ b/lib/friendly_id/reserved.rb
@@ -46,6 +46,7 @@ message to a different field. For example:
     # {FriendlyId::Configuration FriendlyId::Configuration}.
     module Configuration
       attr_accessor :reserved_words
+      attr_accessor :treat_reserved_as_conflict
     end
   end
 end

--- a/lib/friendly_id/scoped.rb
+++ b/lib/friendly_id/scoped.rb
@@ -132,7 +132,7 @@ an example of one way to set this up:
     private :scope_for_slug_generator
 
     def slug_generator
-      friendly_id_config.slug_generator_class.new(scope_for_slug_generator)
+      friendly_id_config.slug_generator_class.new(scope_for_slug_generator, friendly_id_config)
     end
     private :slug_generator
 

--- a/lib/friendly_id/slug_generator.rb
+++ b/lib/friendly_id/slug_generator.rb
@@ -3,11 +3,16 @@ module FriendlyId
   # availability.
   class SlugGenerator
 
-    def initialize(scope)
+    def initialize(scope, config)
       @scope = scope
+      @config = config
     end
 
     def available?(slug)
+      if @config.uses?(::FriendlyId::Reserved) && @config.reserved_words.present? && @config.treat_reserved_as_conflict
+        return false if @config.reserved_words.include?(slug)
+      end
+
       !@scope.exists_by_friendly_id?(slug)
     end
 

--- a/lib/friendly_id/slugged.rb
+++ b/lib/friendly_id/slugged.rb
@@ -370,7 +370,7 @@ Github issue](https://github.com/norman/friendly_id/issues/185) for discussion.
     private :scope_for_slug_generator
 
     def slug_generator
-      friendly_id_config.slug_generator_class.new(scope_for_slug_generator)
+      friendly_id_config.slug_generator_class.new(scope_for_slug_generator, friendly_id_config)
     end
     private :slug_generator
 

--- a/test/reserved_test.rb
+++ b/test/reserved_test.rb
@@ -62,4 +62,14 @@ class ReservedTest < TestCaseClass
     end
   end
 
+  test "should optionally treat reserved words as conflict" do
+    klass = Class.new(model_class) do
+      friendly_id :slug_candidates, :use => [:slugged, :reserved], :reserved_words => %w(new edit), :treat_reserved_as_conflict => true
+    end
+
+    with_instance_of(klass, name: 'new') do |record|
+      assert_match(/new-([0-9a-z]+\-){4}[0-9a-z]+\z/, record.slug)
+    end
+  end
+
 end


### PR DESCRIPTION
Closes #830 

This adds an option to FriendlyId::Reserved::Configuration to treat reserved words as conflicts rather than exceptions. When there is no good candidate, a UUID will be appended, matching the existing conflict behavior.

This could be implemented differently, but I tried to keep with the same patterns used in the gem.

Testing: 
-  Changes are opt-in, so behavior is non-breaking.
- New and old specs pass.