### PR TITLE
Removes multiple warnings when running 'bundle exec rake test'

### DIFF
--- a/lib/friendly_id/finder_methods.rb
+++ b/lib/friendly_id/finder_methods.rb
@@ -50,7 +50,7 @@ module FriendlyId
       when :integer
         Integer(id, 10) rescue false
       when :uuid
-        id.match /\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/
+        id.match(/\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/)
       else
         true
       end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -38,6 +38,10 @@ if ENV["LOG"]
   ActiveRecord::Base.logger = Logger.new($stdout)
 end
 
+if ActiveSupport::VERSION::STRING >= '4.2'
+  ActiveSupport.test_order = :random
+end
+
 module FriendlyId
   module Test
 

--- a/test/history_test.rb
+++ b/test/history_test.rb
@@ -248,7 +248,7 @@ class HistoryTestWithFriendlyFinders < HistoryTest
         begin
           assert model_class.find(old_friendly_id)
           assert model_class.exists?(old_friendly_id), "should exist? by old id for #{model_class.name}"
-        rescue ActiveRecord::RecordNotFound => e
+        rescue ActiveRecord::RecordNotFound
           flunk "Could not find record by old id for #{model_class.name}"
         end
       end


### PR DESCRIPTION
1. ActiveSupport deprecation warning for ActiveSupport 4.2:

    DEPRECATION WARNING: You did not specify a value for the configuration option `active_support.test_order`. In Rails 5, the default value of this option will change from `:sorted` to `:random`.
    To disable this warning and keep the current behavior, you can add the following line to your `config/environments/test.rb`:

      Rails.application.configure do
        config.active_support.test_order = :sorted
      end

    Alternatively, you can opt into the future behavior by setting this option to `:random`. (called from test_order at …/gems/activesupport-4.2.10/lib/active_support/test_case.rb:42)

2. Ruby warning:

    friendly_id/test/history_test.rb:251: warning: assigned but unused variable - e

3. Ruby warning:

    friendly_id/lib/friendly_id/finder_methods.rb:53: warning: ambiguous first argument; put parentheses or a space even after `/' operator