### PR TITLE
Slugs should always find their sluggable, even when they are soft deleted by acts_as_paranoid

### DIFF
--- a/friendly_id.gemspec
+++ b/friendly_id.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'i18n'
   s.add_development_dependency 'ffaker'
   s.add_development_dependency 'simplecov'
-  s.add_development_dependency 'acts_as_paranoid'
 
   s.description = <<-EOM
 FriendlyId is the "Swiss Army bulldozer" of slugging and permalink plugins for

--- a/friendly_id.gemspec
+++ b/friendly_id.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'i18n'
   s.add_development_dependency 'ffaker'
   s.add_development_dependency 'simplecov'
+  s.add_development_dependency 'acts_as_paranoid'
 
   s.description = <<-EOM
 FriendlyId is the "Swiss Army bulldozer" of slugging and permalink plugins for

--- a/lib/friendly_id/slug.rb
+++ b/lib/friendly_id/slug.rb
@@ -3,7 +3,7 @@ module FriendlyId
   #
   # @see FriendlyId::History
   class Slug < ActiveRecord::Base
-    belongs_to :sluggable, :polymorphic => true, required: true
+    belongs_to :sluggable, :polymorphic => true
 
     def sluggable
       sluggable_type.constantize.unscoped { super }

--- a/lib/friendly_id/slug.rb
+++ b/lib/friendly_id/slug.rb
@@ -3,7 +3,11 @@ module FriendlyId
   #
   # @see FriendlyId::History
   class Slug < ActiveRecord::Base
-    belongs_to :sluggable, :polymorphic => true
+    belongs_to :sluggable, :polymorphic => true, required: true
+
+    def sluggable
+      sluggable_type.constantize.unscoped { super }
+    end
 
     def to_param
       slug

--- a/test/history_test.rb
+++ b/test/history_test.rb
@@ -212,27 +212,25 @@ class DependentDestroyTest < HistoryTest
 end
 
 if ActiveRecord::VERSION::STRING >= '5.0'
-  class HistoryTestWithActsAsParanoid < HistoryTest
-    require 'acts_as_paranoid'
+  class HistoryTestWithParanoidDeletes < HistoryTest
     class ParanoidRecord < ActiveRecord::Base
-      acts_as_paranoid
       extend FriendlyId
       friendly_id :name, :use => :history, :dependent => false
+
+      default_scope { where(deleted_at: nil) }
     end
 
     def model_class
       ParanoidRecord
     end
 
-    test 'slug should have a sluggable even when soft deleted via acts_as_paranoid' do
+    test 'slug should have a sluggable even when soft deleted by a library' do
       transaction do
-        assert FriendlyId::Slug.belongs_to_required_by_default
-
         assert FriendlyId::Slug.find_by_slug('paranoid').nil?
         record = model_class.create(name: 'paranoid')
         assert FriendlyId::Slug.find_by_slug('paranoid').present?
 
-        record.destroy
+        record.update_attribute(:deleted_at, Time.now)
 
         orphan_slug = FriendlyId::Slug.find_by_slug('paranoid')
         assert orphan_slug.present?, 'Orphaned slug should exist'

--- a/test/schema.rb
+++ b/test/schema.rb
@@ -41,6 +41,12 @@ module FriendlyId
             add_column table_name, :slug, :string
           end
 
+          paranoid_tables.each do |table_name|
+            add_column table_name, :slug, :string
+            add_column table_name, :deleted_at, :datetime
+            add_index table_name, :deleted_at
+          end
+
           # This will be used to test scopes
           add_column :novels, :novelist_id, :integer
           add_column :novels, :publisher_id, :integer
@@ -78,6 +84,10 @@ module FriendlyId
           %w[journalists articles novelists novels manuals cities]
         end
 
+        def paranoid_tables
+          ["paranoid_records"]
+        end
+
         def tables_with_uuid_primary_key
           ["menu_items"]
         end
@@ -91,7 +101,7 @@ module FriendlyId
         end
 
         def tables
-          simple_tables + slugged_tables + scoped_tables
+          simple_tables + slugged_tables + scoped_tables + paranoid_tables
         end
       end
     end


### PR DESCRIPTION
Probably fixes #822, as the test case is likely what he has encountered. His report most probably required 2 things to be true:

1. He used `friendly_id ... :dependent => false`
2. friendly_id is used in a Rails 5.0 app

Previously, when a sluggable is soft deleted and a slug persists
(i.e. :dependent => false), slug can't find its corresponding
sluggable.

Additionally, in Rails 5.0, belongs_to_required_by_default has been
introduced to be true by default (unless changed back to false), therefore making Friendly::Slug
invalid with the error message 'Sluggable must exist'.