### PR TITLE
Removes redundant HistoryTest

### DIFF
--- a/test/history_test.rb
+++ b/test/history_test.rb
@@ -172,7 +172,7 @@ class HistoryTestWithAutomaticSlugRegeneration < HistoryTest
   end
 end
 
-class DependentDestroyTest < HistoryTest
+class DependentDestroyTest < TestCaseClass
 
   include FriendlyId::Test
 


### PR DESCRIPTION
DependentDestroyTest used to inherit from HistoryTest,
which run tests for a DependentDestroyTest#model_class
that was not overriden anyway.

Previously had 431 tests. Now we have 403 total tests