### PR TITLE
Reduce number of SQL queries when slug history is maintained

### DIFF
--- a/lib/friendly_id/slug.rb
+++ b/lib/friendly_id/slug.rb
@@ -3,7 +3,7 @@ module FriendlyId
   #
   # @see FriendlyId::History
   class Slug < ActiveRecord::Base
-    belongs_to :sluggable, :polymorphic => true
+    belongs_to :sluggable, :polymorphic => true, :inverse_of => :slugs
 
     def sluggable
       sluggable_type.constantize.unscoped { super }


### PR DESCRIPTION
* Used inverse_of to load Slug#sluggable from memory instead of DB:
* Don't perform history maintainance for new records.

``` diff
 SQL (0.3ms)  INSERT INTO `sites` (`name`, `url`, `created_at`, `updated_at`, `cached_slug`, `technical_contact_email`, `customer_service_email`, `account_id`) VALUES ('Company 1', 'http://merchant.com', '2017-11-02 13:15:40', '2017-11-02 13:15:40', 'company-1', 'technical_contact@email.com', 'customer_service@merchant.com', 1448)
- FriendlyId::Slug Load (0.4ms)  SELECT  `friendly_id_slugs`.* FROM `friendly_id_slugs` WHERE `friendly_id_slugs`.`sluggable_id` = 1031 AND `friendly_id_slugs`.`sluggable_type` = 'Site' ORDER BY `friendly_id_slugs`.id DESC LIMIT 1
- SQL (0.4ms)  DELETE FROM `friendly_id_slugs` WHERE `friendly_id_slugs`.`sluggable_id` = 1031 AND `friendly_id_slugs`.`sluggable_type` = 'Site' AND `friendly_id_slugs`.`slug` = 'company-1'
-Site Load (0.4ms)  SELECT  `sites`.* FROM `sites` WHERE `sites`.`id` = 1031 LIMIT 1
 SQL (0.6ms)  INSERT INTO `friendly_id_slugs` (`slug`, `sluggable_id`, `sluggable_type`, `created_at`) VALUES ('company-1', 1031, 'Site',
```
