### PR TITLE
Fix deprecation warnings on Rails 5.2 (and some 5.1 fixes)

### DIFF
--- a/friendly_id.gemspec
+++ b/friendly_id.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'activerecord', '>= 4.0.0'
 
   s.add_development_dependency 'coveralls'
-  s.add_development_dependency 'railties', '~> 4.0'
+  s.add_development_dependency 'railties', '>= 4.0'
   s.add_development_dependency 'minitest', '~> 5.3'
   s.add_development_dependency 'mocha', '~> 1.1'
   s.add_development_dependency 'yard'

--- a/lib/friendly_id/history.rb
+++ b/lib/friendly_id/history.rb
@@ -72,7 +72,7 @@ method.
     # Configures the model instance to use the History add-on.
     def self.included(model_class)
       model_class.class_eval do
-        has_many :slugs, -> {order("#{Slug.quoted_table_name}.id DESC")}, {
+        has_many :slugs, -> {order(id: :desc)}, {
           :as         => :sluggable,
           :dependent  => @friendly_id_config.dependent_value,
           :class_name => Slug.to_s

--- a/lib/friendly_id/migration.rb
+++ b/lib/friendly_id/migration.rb
@@ -1,4 +1,11 @@
-class CreateFriendlyIdSlugs < ActiveRecord::Migration
+migration_class =
+  if ActiveRecord::VERSION::MAJOR >= 5
+    ActiveRecord::Migration[4.2]
+  else
+    ActiveRecord::Migration
+  end
+
+class CreateFriendlyIdSlugs < migration_class
   def change
     create_table :friendly_id_slugs do |t|
       t.string   :slug,           :null => false

--- a/lib/friendly_id/sequentially_slugged.rb
+++ b/lib/friendly_id/sequentially_slugged.rb
@@ -47,7 +47,7 @@ module FriendlyId
       def slug_conflicts
         scope.
           where(conflict_query, slug, sequential_slug_matcher).
-          order(ordering_query).pluck(slug_column)
+          order(Arel.sql(ordering_query)).pluck(Arel.sql(slug_column))
       end
 
       def conflict_query

--- a/test/schema.rb
+++ b/test/schema.rb
@@ -2,7 +2,14 @@ require "friendly_id/migration"
 
 module FriendlyId
   module Test
-    class Schema < ActiveRecord::Migration
+    migration_class =
+      if ActiveRecord::VERSION::MAJOR >= 5
+        ActiveRecord::Migration[4.2]
+      else
+        ActiveRecord::Migration
+      end
+
+    class Schema < migration_class
       class << self
         def down
           CreateFriendlyIdSlugs.down


### PR DESCRIPTION
This fixes migration warnings which were introduced in Rails 5.0 and became errors in Rails 5.1.

This also fixes deprecation warnings introduced in Rails 5.2

> DEPRECATION WARNING: Dangerous query method (method whose arguments are used as raw SQL) called with non-attribute argument(s): "...". Non-attribute arguments will be disallowed in Rails 6.0. This method should not be called with user-provided values, such as request parameters or model attributes. Known-safe values can be passed by wrapping them in Arel.sql().

I believe the build error here is the same that is on master
