### PR TITLE
Solve migration errors with history plugin

### DIFF
--- a/lib/friendly_id/history.rb
+++ b/lib/friendly_id/history.rb
@@ -112,12 +112,11 @@ method.
     # used slug.
     def scope_for_slug_generator
       relation = super
-      return relation if new_record?
-      relation = relation.joins(:slugs).merge(Slug.where('sluggable_id <> ?', id))
-      if friendly_id_config.uses?(:scoped)
-        relation = relation.where(Slug.arel_table[:scope].eq(serialized_scope))
-      end
-      relation
+      return relation unless friendly_id_config.uses?(:scoped)
+
+      relation.includes(:slugs).where(
+        Slug.arel_table[:scope].eq(serialized_scope)
+      )
     end
 
     def create_slug

--- a/test/candidates_test.rb
+++ b/test/candidates_test.rb
@@ -140,4 +140,27 @@ class CandidatesTest < TestCaseClass
     end
   end
 
+  test "should not fail when adding history to existing" do
+    name_collision = "Amsterdam"
+
+    with_instances do |city1, _|
+      assert city1.update name: name_collision, slug: nil
+      assert_equal name_collision.downcase, city1.slug
+
+      klass = Class.new city1.class do
+        friendly_id_config.model_class = city1.class
+        friendly_id_config.use(:history)
+
+        def slug_candidates
+          [:name, [:name, "-alt"]]
+        end
+      end
+      assert klass.friendly_id_config.uses? :history
+
+      city2 = klass.last
+
+      assert city2.update name: name_collision, slug: nil
+      assert_equal "#{name_collision.downcase}-alt", city2.slug
+    end
+  end
 end

--- a/test/history_test.rb
+++ b/test/history_test.rb
@@ -93,6 +93,20 @@ class HistoryTest < TestCaseClass
     end
   end
 
+  test "should not get an old slug used by another" do
+    transaction do
+      record = model_class.create! :name => "Old Name"
+      assert_equal record.slug, "old-name"
+      record.update :name => "New Name", :slug => nil
+      assert_equal record.slug, "new-name"
+
+      new_record = model_class.create! :name => "Old Name"
+      assert_match(/old-name(-\w+){5}/, new_record.slug)
+
+      assert_equal model_class.friendly.find("old-name"), record
+    end
+  end
+
   test "should not create new slugs that match old slugs" do
     transaction do
       first_record = model_class.create! :name => "foo"
@@ -385,6 +399,53 @@ class ScopedHistoryTest < TestCaseClass
       second_record = model_class.create! :city => second_city, :name => 'x'
 
       assert_equal record.slug, second_record.slug
+    end
+  end
+end
+
+class MigrationTest < TestCaseClass
+  include FriendlyId::Test
+
+  class City < ActiveRecord::Base
+    extend FriendlyId
+    friendly_id :slug_candidates, use: :slugged
+    alias_attribute :slug_candidates, :name
+  end
+
+  def with_migrate_scenario(city_name = "New York", &block)
+    transaction do
+      city = City.create! name: city_name
+
+      klass = Class.new City do
+        friendly_id_config.model_class = City
+        friendly_id_config.use(:history)
+
+        def slug_candidates
+          [:name, [:name, "-alt"]]
+        end
+      end
+
+      yield city, klass
+    end
+  end
+
+  test "should not fail when adding history to existing" do
+    name_collision = "Amsterdam"
+
+    with_migrate_scenario(name_collision) do |city, klass|
+      city2 = klass.create! name: "New York"
+
+      assert city2.update name: name_collision, slug: nil
+      assert_equal "#{name_collision.downcase}-alt", city2.slug
+    end
+  end
+
+  test "scope_for_slug_generator should find slugs not in Slug table" do
+    with_migrate_scenario do |city, klass|
+      assert klass.new.send(:scope_for_slug_generator).include? city
+
+      city2 = klass.create! name: city.name
+      assert city2.send(:scope_for_slug_generator).include? city
     end
   end
 end


### PR DESCRIPTION
this one is in reference of #803 

We got conflicting slugs when turning on the history plugin after having used FriendlyId in production for a while. Somehow, history candidates does a superfluous join that 'causes it not to find existing FriendlyIds created before activating the history plugin. This PR is a fix to this, it now accurately finds all FriendlyIds in use and correctly calculates a candidate.