### PR TITLE
Defer loading of ActiveRecord to avoid config issues

### DIFF
--- a/lib/friendly_id.rb
+++ b/lib/friendly_id.rb
@@ -4,6 +4,7 @@ require "friendly_id/base"
 require "friendly_id/object_utils"
 require "friendly_id/configuration"
 require "friendly_id/finder_methods"
+require 'friendly_id/railtie' if defined?(Rails)
 
 =begin
 

--- a/lib/friendly_id/object_utils.rb
+++ b/lib/friendly_id/object_utils.rb
@@ -2,7 +2,6 @@ module FriendlyId
   # Instances of these classes will never be considered a friendly id.
   # @see FriendlyId::ObjectUtils#friendly_id
   UNFRIENDLY_CLASSES = [
-    ActiveRecord::Base,
     Array,
     FalseClass,
     Hash,
@@ -59,6 +58,10 @@ module FriendlyId
       true
     end
   end
+
+  def self.mark_as_unfriendly(klass)
+    klass.send(:include, FriendlyId::UnfriendlyUtils)
+  end
 end
 
 Object.send :include, FriendlyId::ObjectUtils
@@ -66,4 +69,4 @@ Object.send :include, FriendlyId::ObjectUtils
 # Considered unfriendly if object is an instance of an unfriendly class or
 # one of its descendants.
 
-FriendlyId::UNFRIENDLY_CLASSES.each { |klass| klass.send(:include, FriendlyId::UnfriendlyUtils) }
+FriendlyId::UNFRIENDLY_CLASSES.each { |klass| FriendlyId.mark_as_unfriendly(klass) }

--- a/lib/friendly_id/railtie.rb
+++ b/lib/friendly_id/railtie.rb
@@ -1,0 +1,9 @@
+module FriendlyId
+  class Railtie < Rails::Railtie
+    initializer 'friendly_id.setup' do
+      ActiveSupport.on_load(:active_record) do
+        FriendlyId.mark_as_unfriendly(ActiveRecord::Base)
+      end
+    end
+  end
+end

--- a/test/object_utils_test.rb
+++ b/test/object_utils_test.rb
@@ -19,6 +19,8 @@ class ObjectUtilsTest < TestCaseClass
   end
 
   test "ActiveRecord::Base instances should be unfriendly_ids" do
+    FriendlyId.mark_as_unfriendly(ActiveRecord::Base)
+
     model_class = Class.new(ActiveRecord::Base) do
       self.table_name = "authors"
     end


### PR DESCRIPTION
If FriendlyId references `ActiveRecord::Base` while it is loading as part of a Rails application, it triggers the `on_load` event for ActiveRecord, which as part of the loading process sets the current configuration values of ActiveRecord. If any initializers try to influence that configuration (e.g. changing defaults in `new_framework_defaults.rb` for an app that's been upgraded), these changes will have no effect because the configuration has already been set in place.

To avoid this, we need to avoid triggering the `on_load` event by wrapping the reference to `ActiveRecord::Base` in an initializer block. The simplest way of doing this is with a `Railtie`, which will be automatically loaded if FriendlyId is required as part of Rails.

Testing this change is unfortunately quite hard; it would require setting up a Rails test harness application to exercise the Railtie. Since FriendlyId doesn't currently have that, I've tried to keep the
change small.

Fixes #823