### PR TITLE
Remove second 'private' statement from  `lib/friendly_id/candidates.rb`

### DIFF
--- a/lib/friendly_id/candidates.rb
+++ b/lib/friendly_id/candidates.rb
@@ -63,8 +63,6 @@ module FriendlyId
       slug.present?
     end
 
-    private
-
     def reserved?(slug)
       config = @object.friendly_id_config
       return false unless config.uses? ::FriendlyId::Reserved


### PR DESCRIPTION
Hello,

it's nothing critical, just a minor style PR: `lib/friendly_id/candidates.rb` had 2 **private** statements 😊