### PR TITLE
fix temp generators solution for Rails 5.1+

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,6 @@ Generate the friendly configuration file
 rails generate friendly_id
 ```
 
->Temp solution for Rails 5.1+ : Before running the migration, go into the generated migration file and specify the Rails version:  
-`class CreateFriendlyIdSlugs < ActiveRecord::Migration[5.1]`  
-
 Run the migration scripts
 
 ```shell
@@ -91,7 +88,7 @@ User.create! name: "Joe Schmoe"
 You can then access the user show page using the URL http://localhost:3000/users/joe-schmoe.
 
 
-If you're adding FriendlyId to an existing app and need to generate slugs for 
+If you're adding FriendlyId to an existing app and need to generate slugs for
 existing users, do this from the console, runner, or add a Rake task:
 
 ```ruby

--- a/lib/friendly_id/migration.rb
+++ b/lib/friendly_id/migration.rb
@@ -7,6 +7,7 @@ class CreateFriendlyIdSlugs < ActiveRecord::Migration<%= migration_version %>
       t.string   :scope
       t.datetime :created_at
     end
+    
     add_index :friendly_id_slugs, :sluggable_id
     add_index :friendly_id_slugs, %i[slug sluggable_type], length: { slug: 140, sluggable_type: 50 }
     add_index :friendly_id_slugs, %i[slug sluggable_type scope], length: { slug: 70, sluggable_type: 50, scope: 70 }, unique: true

--- a/lib/generators/friendly_id_generator.rb
+++ b/lib/generators/friendly_id_generator.rb
@@ -8,19 +8,28 @@ class FriendlyIdGenerator < ActiveRecord::Generators::Base
   # new table name. Our generator always uses 'friendly_id_slugs', so we just set a random name here.
   argument :name, type: :string, default: 'random_name'
 
-  class_option :'skip-migration', :type => :boolean, :desc => "Don't generate a migration for the slugs table"
   class_option :'skip-initializer', :type => :boolean, :desc => "Don't generate an initializer"
+  class_option :'skip-migration', :type => :boolean, :desc => "Don't generate a migration for the slugs table"
 
   source_root File.expand_path('../../friendly_id', __FILE__)
 
   # Copies the migration template to db/migrate.
   def copy_files
     return if options['skip-migration']
-    migration_template 'migration.rb', 'db/migrate/create_friendly_id_slugs.rb'
+    migration_template 'migration.rb', 'db/migrate/create_friendly_id_slugs.rb',
+                       migration_version: migration_version
   end
 
   def create_initializer
     return if options['skip-initializer']
     copy_file 'initializer.rb', 'config/initializers/friendly_id.rb'
+  end
+
+  def migration_version
+    "[#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}]" if rails5?
+  end
+
+  def rails5?
+    ActiveRecord::VERSION::MAJOR >= 5
   end
 end

--- a/test/migration_mock.rb
+++ b/test/migration_mock.rb
@@ -1,4 +1,4 @@
-class CreateFriendlyIdSlugs < ActiveRecord::Migration<%= migration_version %>
+class CreateFriendlyIdSlugs < ActiveRecord::Migration[4.2]
   def change
     create_table :friendly_id_slugs do |t|
       t.string   :slug,           null: false

--- a/test/schema.rb
+++ b/test/schema.rb
@@ -1,4 +1,4 @@
-require "friendly_id/migration"
+require 'migration_mock'
 
 module FriendlyId
   module Test


### PR DESCRIPTION
Hey there.

I fixed your temp solution for Rails 5 migration templates. And it seems more elegant now.
Also it would be nice if we can get rid of this migration object, because it's seems like hack to me, that generator template were used across tests as a real object. That's why I moved it to migration_mock.rb
Anyway I'm ready to talk. :)