### PR TITLE
Fix README.md typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ rails generate friendly_id
 Run the migration scripts
 
 ```shell
-rails db:migrate
+rake db:migrate
 ```
 
 Edit the `app/models/user.rb` file as the following:


### PR DESCRIPTION
I assume that it's a typo and here should be 'rake db:migrate'.

Thanks,
Alex.