### PR TITLE
Fix to_param in ActiveRecord callbacks

### DIFF
--- a/lib/friendly_id/base.rb
+++ b/lib/friendly_id/base.rb
@@ -261,12 +261,7 @@ often better and easier to use {FriendlyId::Slugged slugs}.
     # Either the friendly_id, or the numeric id cast to a string.
     def to_param
       if friendly_id_config.routes == :friendly
-        if attribute_changed?(friendly_id_config.query_field)
-          diff = changes[friendly_id_config.query_field]
-          diff.first || diff.second
-        else
-          friendly_id.presence.to_param || super
-        end
+        friendly_id.presence.to_param || super
       else
         super
       end


### PR DESCRIPTION
(... and also remove deprecation warnings under Rails 5.1)

I originally started investigating this as part of #816 (see some discussion there about `to_param` from the perspective of the deprecation warnings), and also #862 (which features the first version of the callback test I've used here).

On the latter, it became clear that there were actually two issues: the deprecation warnings, and the behaviour of `to_param` in callbacks. I decided to write an explicit test for the callback behaviour here, and included a bunch of other tests about `to_param` in various scenarios.

The "fix" basically involves deleting all the dirty tracking code within `to_param`, which seems superficially crazy to me, but all the tests pass, so either we don't need that code, or we are missing some key tests around this behaviour.