### PR TITLE
Remove temp solution for Rails 5 from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,6 @@ Generate the friendly configuration file
 rails generate friendly_id
 ```
 
->Temp solution for Rails 5.1+ : Before running the migration, go into the generated migration file and specify the Rails version:  
-`class CreateFriendlyIdSlugs < ActiveRecord::Migration[5.1]`  
-
 Run the migration scripts
 
 ```shell


### PR DESCRIPTION
Migration warnings on Rails 5 were fixed in https://github.com/norman/friendly_id/commit/2a7121df300e0acc2e18c75f83ad9e17152f5a9f