### PR TITLE
Fixes for 'Directly inheriting from ActiveRecord::Migration is not supported' errors

### DIFF
--- a/lib/friendly_id/migration.rb
+++ b/lib/friendly_id/migration.rb
@@ -1,11 +1,4 @@
-MIGRATION_CLASS =
-  if ActiveRecord::VERSION::MAJOR >= 5
-    ActiveRecord::Migration["#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}"]
-  else
-    ActiveRecord::Migration
-  end
-
-class CreateFriendlyIdSlugs < MIGRATION_CLASS
+class CreateFriendlyIdSlugs < ActiveRecord::Migration<%= migration_version %>
   def change
     create_table :friendly_id_slugs do |t|
       t.string   :slug,           :null => false

--- a/lib/generators/friendly_id_generator.rb
+++ b/lib/generators/friendly_id_generator.rb
@@ -23,4 +23,14 @@ class FriendlyIdGenerator < ActiveRecord::Generators::Base
     return if options['skip-initializer']
     copy_file 'initializer.rb', 'config/initializers/friendly_id.rb'
   end
+
+  private
+
+  def rails5?
+    Rails.version.start_with? '5'
+  end
+
+  def migration_version
+    "[#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}]" if rails5?
+  end
 end

--- a/lib/generators/friendly_id_generator.rb
+++ b/lib/generators/friendly_id_generator.rb
@@ -16,7 +16,7 @@ class FriendlyIdGenerator < ActiveRecord::Generators::Base
   # Copies the migration template to db/migrate.
   def copy_files
     return if options['skip-migration']
-    migration_template 'migration.rb', 'db/migrate/create_friendly_id_slugs.rb'
+    migration_template 'migration.rb', 'db/migrate/create_friendly_id_slugs.rb', migration_version: migration_version
   end
 
   def create_initializer


### PR DESCRIPTION
resolves #805 and #869 

After encountering this error today, these changes pass the variable of the rails version to the template if Rails version > 5.

Tested with Rails version 5.2, `db:migrate` completes with no errors