### PR TITLE
Fix exists? to behave the same as find for numeric slugs

### DIFF
--- a/lib/friendly_id/finder_methods.rb
+++ b/lib/friendly_id/finder_methods.rb
@@ -25,8 +25,9 @@ module FriendlyId
 
     # Returns true if a record with the given id exists.
     def exists?(conditions = :none)
-      return super unless conditions.friendly_id?
-      exists_by_friendly_id?(conditions)
+      return super if conditions.unfriendly_id?
+      return true if exists_by_friendly_id?(conditions)
+      super
     end
 
     # Finds exclusively by the friendly id, completely bypassing original

--- a/test/numeric_slug_test.rb
+++ b/test/numeric_slug_test.rb
@@ -1,0 +1,31 @@
+require 'helper'
+
+class NumericSlugTest < TestCaseClass
+  include FriendlyId::Test
+  include FriendlyId::Test::Shared::Core
+
+  def model_class
+    Article
+  end
+
+  test "should generate numeric slugs" do
+    transaction do
+      record = model_class.create! :name => "123"
+      assert_equal "123", record.slug
+    end
+  end
+
+  test "should find by numeric slug" do
+    transaction do
+      record = model_class.create! :name => "123"
+      assert_equal model_class.friendly.find("123").id, record.id
+    end
+  end
+
+  test "should exist? by numeric slug" do
+    transaction do
+      record = model_class.create! :name => "123"
+      assert model_class.friendly.exists?("123")
+    end
+  end
+end


### PR DESCRIPTION
If a record is created with a slug that is an integer (123, for example), `Model.friendly.find("123")` finds the correct record with slug of "123", but `Model.friendly.exists?("123")` returns false.

Referencing the comment [here](https://github.com/norman/friendly_id/blob/master/lib/friendly_id/finder_methods.rb#L8):
```ruby
    # If the id is a numeric string like '123' it will first look for a friendly
    # id matching '123' and then fall back to looking for a record with the
    # numeric id '123'.
```
`.find()` is correctly finding the record by its slug "123".  [Code reference](https://github.com/norman/friendly_id/blob/master/lib/friendly_id/finder_methods.rb#L18)

```ruby
    def find(*args)
      id = args.first
      return super if args.count != 1 || id.unfriendly_id?
      first_by_friendly_id(id).tap {|result| return result unless result.nil?}
      return super if potential_primary_key?(id)
      raise ActiveRecord::RecordNotFound, "can't find record with friendly id: #{id.inspect}"
    end
```

However, `.exists?` does not behave in the same way.  It immediately passes to super looking for a record with an id of 123 based on `.friendly_id?`. [Code reference](https://github.com/norman/friendly_id/blob/master/lib/friendly_id/finder_methods.rb#L27)
```ruby
    def exists?(conditions = :none)
      return super unless conditions.friendly_id?
      exists_by_friendly_id?(conditions)
    end
```

I've updated `.exists?` to take a similar approach to find in looking for a record with the slug first and only passing it to super if none is found.