### PR TITLE
fix History + SequentiallySlugged + Scope issues

### DIFF
--- a/lib/friendly_id/history.rb
+++ b/lib/friendly_id/history.rb
@@ -110,9 +110,10 @@ method.
     # to be conflicts. This will allow a record to revert to a previously
     # used slug.
     def scope_for_slug_generator
-      relation = super
-      return relation if new_record?
-      relation = relation.joins(:slugs).merge(Slug.where('sluggable_id <> ?', id))
+      relation = super.joins(:slugs)
+      unless new_record?
+        relation = relation.merge(Slug.where('sluggable_id <> ?', id))
+      end
       if friendly_id_config.uses?(:scoped)
         relation = relation.where(Slug.arel_table[:scope].eq(serialized_scope))
       end

--- a/lib/friendly_id/scoped.rb
+++ b/lib/friendly_id/scoped.rb
@@ -122,6 +122,9 @@ an example of one way to set this up:
     end
 
     def scope_for_slug_generator
+      if friendly_id_config.uses?(:History)
+        return super
+      end
       relation = self.class.base_class.unscoped.friendly
       friendly_id_config.scope_columns.each do |column|
         relation = relation.where(column => send(column))

--- a/lib/friendly_id/sequentially_slugged.rb
+++ b/lib/friendly_id/sequentially_slugged.rb
@@ -7,17 +7,11 @@ module FriendlyId
     def resolve_friendly_id_conflict(candidate_slugs)
       candidate = candidate_slugs.first
       return if candidate.nil?
-      scope = scope_for_slug_generator
-      if friendly_id_config.uses?(:history)
-        base_class = Slug
-      else
-        base_class = self.class.base_class
-      end
-      SequentialSlugCalculator.new(scope,
+      SequentialSlugCalculator.new(scope_for_slug_generator,
                                   candidate,
                                   friendly_id_config.slug_column,
                                   friendly_id_config.sequence_separator,
-                                  base_class).next_slug
+                                  slug_base_class).next_slug
     end
 
     class SequentialSlugCalculator
@@ -77,6 +71,16 @@ module FriendlyId
         length_command = "LENGTH"
         length_command = "LEN" if scope.connection.adapter_name =~ /sqlserver/i
         "#{length_command}(#{slug_column}) ASC, #{slug_column} ASC"
+      end
+    end
+
+    private
+
+    def slug_base_class
+      if friendly_id_config.uses?(:history)
+        Slug
+      else
+        self.class.base_class
       end
     end
   end

--- a/lib/friendly_id/sequentially_slugged.rb
+++ b/lib/friendly_id/sequentially_slugged.rb
@@ -7,11 +7,17 @@ module FriendlyId
     def resolve_friendly_id_conflict(candidate_slugs)
       candidate = candidate_slugs.first
       return if candidate.nil?
-      SequentialSlugCalculator.new(scope_for_slug_generator,
+      scope = scope_for_slug_generator
+      if friendly_id_config.uses?(:history)
+        base_class = Slug
+      else
+        base_class = self.class.base_class
+      end
+      SequentialSlugCalculator.new(scope,
                                   candidate,
                                   friendly_id_config.slug_column,
                                   friendly_id_config.sequence_separator,
-                                  self.class.base_class).next_slug
+                                  base_class).next_slug
     end
 
     class SequentialSlugCalculator


### PR DESCRIPTION
`SequentiallySlugged` with `History` doesn't look into previously used slugs, which can result in a wrong `last_sequence_number` and failure.