### PR TITLE
Scoped: generate new slug if scope changed

### DIFF
--- a/lib/friendly_id/scoped.rb
+++ b/lib/friendly_id/scoped.rb
@@ -139,6 +139,10 @@ an example of one way to set this up:
     end
     private :slug_generator
 
+    def should_generate_new_friendly_id?
+      (changed & friendly_id_config.scope_columns).any? || super
+    end
+
     # This module adds the `:scope` configuration option to
     # {FriendlyId::Configuration FriendlyId::Configuration}.
     module Configuration

--- a/test/scoped_test.rb
+++ b/test/scoped_test.rb
@@ -81,4 +81,17 @@ class ScopedTest < TestCaseClass
     end
   end
 
+  test "should generate new slug when scope changes" do
+    transaction do
+      novelist = Novelist.create! :name => "a"
+      publisher = Publisher.create! :name => "b"
+      novel1 = Novel.create! :name => "c", :novelist => novelist, :publisher => publisher
+      novel2 = Novel.create! :name => "c", :novelist => novelist, :publisher => Publisher.create(:name => "d")
+      assert_equal novel1.friendly_id, novel2.friendly_id
+      novel2.publisher = publisher
+      novel2.save!
+      assert novel2.friendly_id != novel1.friendly_id
+    end
+  end
+
 end


### PR DESCRIPTION
When using `Scoped` you have to manually watch for scope changes and regenerate slugs. Why don't we do that automatically?