### PR TITLE
Fixes ''Directly inheriting from ActiveRecord::Migration is not supported"

### DIFF
--- a/lib/friendly_id.rb
+++ b/lib/friendly_id.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+require 'erb'
 require 'active_record'
 require "friendly_id/base"
 require "friendly_id/object_utils"

--- a/lib/friendly_id/active_record_version.rb
+++ b/lib/friendly_id/active_record_version.rb
@@ -1,0 +1,15 @@
+module FriendlyId
+
+  class ActiveRecordVersion
+    class << self
+      def gt_than_5?
+        return true if ActiveRecord::VERSION::MAJOR >= 5
+        false
+      end
+      def migration_version
+        "[#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}]" if gt_than_5? 
+      end
+    end
+  end
+  
+end

--- a/lib/friendly_id/migration.erb.rb
+++ b/lib/friendly_id/migration.erb.rb
@@ -1,11 +1,4 @@
-MIGRATION_CLASS =
-  if ActiveRecord::VERSION::MAJOR >= 5
-    ActiveRecord::Migration["#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}"]
-  else
-    ActiveRecord::Migration
-  end
-
-class CreateFriendlyIdSlugs < MIGRATION_CLASS
+class CreateFriendlyIdSlugs < ActiveRecord::Migration<%= FriendlyId::ActiveRecordVersion.migration_version %>
   def change
     create_table :friendly_id_slugs do |t|
       t.string   :slug,           :null => false

--- a/lib/generators/friendly_id_generator.rb
+++ b/lib/generators/friendly_id_generator.rb
@@ -1,5 +1,6 @@
 require 'rails/generators'
 require "rails/generators/active_record"
+require 'friendly_id/active_record_version'
 
 # This generator adds a migration for the {FriendlyId::History
 # FriendlyId::History} addon.
@@ -16,7 +17,7 @@ class FriendlyIdGenerator < ActiveRecord::Generators::Base
   # Copies the migration template to db/migrate.
   def copy_files
     return if options['skip-migration']
-    migration_template 'migration.rb', 'db/migrate/create_friendly_id_slugs.rb'
+    migration_template 'migration.erb.rb', 'db/migrate/create_friendly_id_slugs.rb'
   end
 
   def create_initializer

--- a/test/schema.rb
+++ b/test/schema.rb
@@ -1,15 +1,25 @@
-require "friendly_id/migration"
+require 'friendly_id/active_record_version'
+
+class CreateFriendlyIdSlugs < eval("ActiveRecord::Migration#{FriendlyId::ActiveRecordVersion.migration_version}")
+  def change
+    create_table :friendly_id_slugs do |t|
+      t.string   :slug,           :null => false
+      t.integer  :sluggable_id,   :null => false
+      t.string   :sluggable_type, :limit => 50
+      t.string   :scope
+      t.datetime :created_at
+    end
+    add_index :friendly_id_slugs, :sluggable_id
+    add_index :friendly_id_slugs, [:slug, :sluggable_type], length: { slug: 140, sluggable_type: 50 }
+    add_index :friendly_id_slugs, [:slug, :sluggable_type, :scope], length: { slug: 70, sluggable_type: 50, scope: 70 }, unique: true
+    add_index :friendly_id_slugs, :sluggable_type
+  end
+end
+
 
 module FriendlyId
   module Test
-    migration_class =
-      if ActiveRecord::VERSION::MAJOR >= 5
-        ActiveRecord::Migration[4.2]
-      else
-        ActiveRecord::Migration
-      end
-
-    class Schema < migration_class
+    class Schema < eval("ActiveRecord::Migration#{FriendlyId::ActiveRecordVersion.migration_version}")
       class << self
         def down
           CreateFriendlyIdSlugs.down


### PR DESCRIPTION
Tested with Rails 5.2 and 4.2 rake db:migrate works fine. 
Have used ACTIVERECORD::VERSION instead of RAILS::VERSION as active record is a dependency. 

resolves #805 and #869
