### PR TITLE
Use composite index for queries by sluggable

### DIFF
--- a/lib/friendly_id/migration.rb
+++ b/lib/friendly_id/migration.rb
@@ -14,9 +14,8 @@ class CreateFriendlyIdSlugs < MIGRATION_CLASS
       t.string   :scope
       t.datetime :created_at
     end
-    add_index :friendly_id_slugs, :sluggable_id
+    add_index :friendly_id_slugs, [:sluggable_type, :sluggable_id]
     add_index :friendly_id_slugs, [:slug, :sluggable_type], length: { slug: 140, sluggable_type: 50 }
     add_index :friendly_id_slugs, [:slug, :sluggable_type, :scope], length: { slug: 70, sluggable_type: 50, scope: 70 }, unique: true
-    add_index :friendly_id_slugs, :sluggable_type
   end
 end


### PR DESCRIPTION
A `sluggable_id` index alone isn't much use since the `sluggable_id` only makes sense in the context of a `sluggable_type`. This allows for much faster look ups (and better query planning) when searching by a sluggable.