### PR TITLE
Add missing step to the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Generate the friendly configuration file and a new migration
 rails generate friendly_id
 ```
 
-Note: You can get rid of the `CreateFriendlyIdSlugs` migration if you won't use the slug history feature. ([Read more](http://norman.github.io/friendly_id/FriendlyId/History.html))
+Note: You can delete the `CreateFriendlyIdSlugs` migration if you won't use the slug history feature. ([Read more](https://norman.github.io/friendly_id/FriendlyId/History.html))
 
 Run the migration scripts
 

--- a/README.md
+++ b/README.md
@@ -48,11 +48,18 @@ And then execute:
 bundle install
 ```
 
-Generate the friendly configuration file
+Add a `slug` column to the desired table (e.g. `Users`)
+```shell
+rails g migration AddSlugToUsers slug:uniq
+```
+
+Generate the friendly configuration file and a new migration
 
 ```shell
 rails generate friendly_id
 ```
+
+Note: You can get rid of the `CreateFriendlyIdSlugs` migration if you won't use the slug history feature. ([Read more](http://norman.github.io/friendly_id/FriendlyId/History.html))
 
 Run the migration scripts
 


### PR DESCRIPTION
Re: #886 

If you follow the steps on the README you'll see a `Undefined method 'slug'` error. Looks like it's because there's a missing step in the documentation. 
Let me know what you think. Thanks!