### PR TITLE
Pass all 4 parameters (message, model_name, query_field and id) to ActiveRecord::RecordNotFound.new when raising the exception.

### DIFF
--- a/lib/friendly_id/finder_methods.rb
+++ b/lib/friendly_id/finder_methods.rb
@@ -20,7 +20,7 @@ module FriendlyId
       return super if args.count != 1 || id.unfriendly_id?
       first_by_friendly_id(id).tap {|result| return result unless result.nil?}
       return super if potential_primary_key?(id)
-      raise ActiveRecord::RecordNotFound, "can't find record with friendly id: #{id.inspect}"
+      raise ActiveRecord::RecordNotFound.new "can't find record with friendly id: #{id.inspect}", name, friendly_id_config.query_field, id
     end
 
     # Returns true if a record with the given id exists.
@@ -34,7 +34,7 @@ module FriendlyId
     # `find`.
     # @raise ActiveRecord::RecordNotFound
     def find_by_friendly_id(id)
-      first_by_friendly_id(id) or raise ActiveRecord::RecordNotFound, "can't find record with friendly id: #{id.inspect}"
+      first_by_friendly_id(id) or raise ActiveRecord::RecordNotFound.new "can't find record with friendly id: #{id.inspect}", name, friendly_id_config.query_field, id
     end
 
     def exists_by_friendly_id?(id)


### PR DESCRIPTION
In my Rails App, I had written a common rescue for `ActiveRecord::RecordNotFound` in `ApplicationController`.

When this exception is rescued, I form a common error message:

    rescue_from ActiveRecord::RecordNotFound, :with => :handle_404
    def handle_404
        @exception = exception
        @not_found_message = "The #{@exception.model.name.underscore.humanize} you are looking for was not found"
         render :not_found
    end

This worked fine when the model does not use `FriendlyId`. 

In order to make this work with models that use `FriendlyId`, I have passed all four parameters  (message, model_name, query_field and id) to ActiveRecord::RecordNotFound.new when it is being raised in finder_methods.rb.