### PR TITLE
Record history when scope changes but slug does not

### DIFF
--- a/lib/friendly_id/history.rb
+++ b/lib/friendly_id/history.rb
@@ -141,6 +141,7 @@ method.
       if friendly_id_config.uses?(:scoped)
         check = check && latest_history.scope == serialized_scope
       end
+      check
     end
   end
 end

--- a/lib/friendly_id/history.rb
+++ b/lib/friendly_id/history.rb
@@ -122,7 +122,7 @@ method.
 
     def create_slug
       return unless friendly_id
-      return if slugs.first.try(:slug) == friendly_id
+      return if history_is_up_to_date?
       # Allow reversion back to a previously used slug
       relation = slugs.where(:slug => friendly_id)
       if friendly_id_config.uses?(:scoped)
@@ -132,6 +132,14 @@ method.
       slugs.create! do |record|
         record.slug = friendly_id
         record.scope = serialized_scope if friendly_id_config.uses?(:scoped)
+      end
+    end
+
+    def history_is_up_to_date?
+      latest_history = slugs.first
+      check = latest_history.try(:slug) == friendly_id
+      if friendly_id_config.uses?(:scoped)
+        check = check && latest_history.scope == serialized_scope
       end
     end
   end

--- a/test/history_test.rb
+++ b/test/history_test.rb
@@ -377,6 +377,33 @@ class ScopedHistoryTest < TestCaseClass
     end
   end
 
+  test "should record history when scope changes" do
+    transaction do
+      city1 = City.create!
+      city2 = City.create!
+      with_instance_of(Restaurant) do |record|
+        record.name = "x"
+        record.slug = nil
+
+        record.city = city1
+        record.save!
+        assert_equal("city_id:#{city1.id}", record.slugs.reload.first.scope)
+        assert_equal("x", record.slugs.reload.first.slug)
+
+        record.city = city2
+        record.save!
+        assert_equal("city_id:#{city2.id}", record.slugs.reload.first.scope)
+
+        record.name = "y"
+        record.slug = nil
+        record.city = city1
+        record.save!
+        assert_equal("city_id:#{city1.id}", record.slugs.reload.first.scope)
+        assert_equal("y", record.slugs.reload.first.slug)
+      end
+    end
+  end
+
   test "should allow equal slugs in different scopes" do
     transaction do
       city = City.create!


### PR DESCRIPTION
In order to record history, we should check if there is a new slug.
If the record uses the scoped module we should also check if there is **a change in the scope**.
