### PR TITLE
Set required_ruby_version to >= 2.1.0

### DIFF
--- a/friendly_id.gemspec
+++ b/friendly_id.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.require_paths     = ["lib"]
   s.license           = 'MIT'
 
-  s.required_ruby_version = '>= 1.9.3'
+  s.required_ruby_version = '>= 2.1.0'
 
   s.add_dependency 'activerecord', '>= 4.0.0'
 


### PR DESCRIPTION
According to https://github.com/norman/friendly_id/pull/824