### PR TITLE
use destroy_all rather than delete_all when creating historical…

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@ suggestions, ideas and improvements to FriendlyId.
 
 ## Unreleased
 
+* Use `destroy_all` rather than `delete_all` when creating historical slugs ([#924](https://github.com/norman/friendly_id/pull/924))
 * Avoid using deprecated `update_attributes`. ([#922](https://github.com/norman/friendly_id/pull/922))
 
 ## 5.3.0 (2019-09-25)

--- a/lib/friendly_id/history.rb
+++ b/lib/friendly_id/history.rb
@@ -1,4 +1,3 @@
-
 module FriendlyId
 
 =begin

--- a/lib/friendly_id/history.rb
+++ b/lib/friendly_id/history.rb
@@ -1,3 +1,4 @@
+
 module FriendlyId
 
 =begin
@@ -128,7 +129,7 @@ method.
       if friendly_id_config.uses?(:scoped)
         relation = relation.where(:scope => serialized_scope)
       end
-      relation.delete_all
+      relation.destroy_all
       slugs.create! do |record|
         record.slug = friendly_id
         record.scope = serialized_scope if friendly_id_config.uses?(:scoped)


### PR DESCRIPTION
Our application adds an `after_commit` callback to `FriendlyId::Slug`. The usage of `delete_all` rather than `destroy_all` in `FriendlyId::History::FinderMethods#create_slug` means that this callback is not always invoked.

This PR changes this `delete_all` to a `destroy_all`, which will invoke callbacks for the deleted records. Performance impact should be minimal given that (at most) 1 record is loaded and then deleted.

Additionally: I noticed that no tests failed when i removed the `delete_all` call entirely. I think the test I've added will guard against that.