### PR TITLE
Updating slugged normalize method to preserve case

### DIFF
--- a/lib/friendly_id/slugged.rb
+++ b/lib/friendly_id/slugged.rb
@@ -288,7 +288,7 @@ Github issue](https://github.com/norman/friendly_id/issues/185) for discussion.
     # @param [#to_s] value The value used as the basis of the slug.
     # @return The candidate slug text, without a sequence.
     def normalize_friendly_id(value)
-      value = value.to_s.parameterize
+      value = value.to_s.parameterize(preserve_case: true)
       value = value[0...friendly_id_config.slug_limit] if friendly_id_config.slug_limit
       value
     end


### PR DESCRIPTION
This PR provides the ability for the `normalize_friendly_id` method to preserve case when parameterizing slug value. This allows for cleaner URLs where sometimes letter case carries meaning.