### PR TITLE
Remove MySQL deadlock caused by delete_all in history.

### DIFF
--- a/lib/friendly_id/history.rb
+++ b/lib/friendly_id/history.rb
@@ -128,7 +128,7 @@ method.
       if friendly_id_config.uses?(:scoped)
         relation = relation.where(:scope => serialized_scope)
       end
-      relation.destroy_all
+      relation.destroy_all unless relation.empty?
       slugs.create! do |record|
         record.slug = friendly_id
         record.scope = serialized_scope if friendly_id_config.uses?(:scoped)


### PR DESCRIPTION
Before this change, when saving a new model with history, the following SQL
is generated to populate the `friendly_id_slugs` table (example uses `scoped` as well):

```sql
-- FriendlyId::Slug Load
SELECT  friendly_id_slugs.* FROM friendly_id_slugs WHERE friendly_id_slugs.sluggable_id = 9999 AND friendly_id_slugs.sluggable_type = 'Thing' ORDER BY friendly_id_slugs.id DESC LIMIT 1;
-- FriendlyId::Slug Destroy
DELETE FROM friendly_id_slugs WHERE friendly_id_slugs.sluggable_id = 9999 AND friendly_id_slugs.sluggable_type = 'Thing' AND friendly_id_slugs.slug = 'poodle' AND friendly_id_slugs.scope = 'account_id:1'
-- Thing Load
SELECT  things.* FROM things WHERE things.id = 9999 LIMIT 1
-- FriendlyId::Slug Create
INSERT INTO friendly_id_slugs (slug, sluggable_id, sluggable_type, scope, created_at) VALUES ('poodle', 9999, 'Thing', 'account_id:1', '2019-12-07 03:34:59')
```

The purpose of the `delete_all` / `DELETE FROM` is to ensure that the newly created slug will be at the front of `slugs` and is the only occurrence in `slugs`.

Unfortunately, the above can easily deadlock in MySQL when instances of `Thing` and associated slugs are created concurrently.

From the [MySQL docs](https://dev.mysql.com/doc/refman/8.0/en/innodb-locks-set.html):
> `DELETE FROM ... WHERE ...` sets an exclusive next-key lock on every record the search encounters. However, only an index record lock is required for statements that lock rows using a unique index to search for a unique row.

When two transactions run simultaneously, even if they're creating different slugs on different
`Thing` instances, both transactions will take an exclusive lock on every record the search encounters.  This happens even when nothing is actually deleted (which is the case for newly created models).

The impact of these exclusive locks is that each of the subsequent `INSERT INTO friendly_id_slugs' is waiting for the exclusive lock held by the other transaction to be released... deadlock.

Specifically, here's the flow:

```sql
-- Txn (1): FriendlyId::Slug Load
-- Txn (1): FriendlyId::Slug Destroy
-- Txn (1): Thing Load

-- Txn (2): FriendlyId::Slug Load
-- Txn (2): FriendlyId::Slug Destroy
-- Txn (2): Thing Load

-- (this one hangs because it's waiting for the exclusive lock held by Txn (2))
-- Txn (1): FriendlyId::Slug Create

-- (this causes the deadlock because it's waiting for exclusive lock held by Txn (1)... MySQL aborts one of the txns)
-- Txn (2): FriendlyId::Slug Create
```

Running the `delete_all` only if it's applicable allows the common flow of creating new instances of `Thing` to not deadlock.  There is still a chance that concurrent *update* to models will still deadlock, but this is better than it was before.