### PR TITLE
 Run Actions on master `push` and `pull_request`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [ push ]
+on:
+  push:
+    branches:
+      - 'master'
+  pull_request:
 jobs:
   test:
     strategy:
@@ -10,7 +14,6 @@ jobs:
         gemfile: [ '6.0', '5.2', '5.1', '5.0' ]
         ruby: [ '2.6.x', '2.5.x' ]
       fail-fast: false
-      max-parallel: 20
     runs-on: ubuntu-latest
     name: ${{ matrix.ruby }} ${{ matrix.database }} rails-${{ matrix.gemfile }}
     steps:


### PR DESCRIPTION
When we use GitHub Actions, but we only run on the `push` event,
it only runs when someone pushes to the source repo at norman/friendly_id.

This isn't what we want, as we want to test other contributors' changes
as well.

Now Actions will run on push to master branch, and pull request.

I've also removed `max-parallel` as apparently it will already run the most
that it can according to [the docs](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_idstrategymax-parallel).