### PR TITLE
fix: Scoped#should_generate_new_friendly_id? only for persisted record

### DIFF
--- a/lib/friendly_id/scoped.rb
+++ b/lib/friendly_id/scoped.rb
@@ -140,6 +140,8 @@ an example of one way to set this up:
     private :slug_generator
 
     def should_generate_new_friendly_id?
+      return super if new_record?
+
       (changed & friendly_id_config.scope_columns).any? || super
     end
 


### PR DESCRIPTION
Since the introduction of `Scoped#should_generate_new_friendly_id?`, it is no longer possible to create a record with a predefined slug.

I suggest to check if it is a `new_record`. But maybe it's more relevant to see if `slug_changed?` ?