### PR TITLE
Raise a friendly exception if no primary key

### DIFF
--- a/lib/friendly_id/slugged.rb
+++ b/lib/friendly_id/slugged.rb
@@ -365,6 +365,7 @@ Github issue](https://github.com/norman/friendly_id/issues/185) for discussion.
       scope = self.class.base_class.unscoped
       scope = scope.friendly unless scope.respond_to?(:exists_by_friendly_id?)
       primary_key_name = self.class.primary_key
+      raise ::ActiveRecord::UnknownPrimaryKey.new(self.class) unless primary_key_name
       scope.where(self.class.base_class.arel_table[primary_key_name].not_eq(send(primary_key_name)))
     end
     private :scope_for_slug_generator


### PR DESCRIPTION
While attempting to run tests on an unfamiliar application, I got an
error saying "nil is not a string or symbol". This was due to my
database not having primary keys set up (a botched pg_dump). This change
makes the error easier to understand.

Apologies: I'm not sure how to test this, but I'm happy to try if you give me a hint. :-)