### PR TITLE
Fix/Slug Validation in unset_slug_if_invalid

### DIFF
--- a/lib/friendly_id/slugged.rb
+++ b/lib/friendly_id/slugged.rb
@@ -375,7 +375,7 @@ Github issue](https://github.com/norman/friendly_id/issues/185) for discussion.
     private :slug_generator
 
     def unset_slug_if_invalid
-      if errors.present? && attribute_changed?(friendly_id_config.query_field.to_s)
+      if errors[friendly_id_config.query_field].present? && attribute_changed?(friendly_id_config.query_field.to_s)
         diff = changes[friendly_id_config.query_field]
         send "#{friendly_id_config.slug_column}=", diff.first
       end


### PR DESCRIPTION
This PR replaces https://github.com/norman/friendly_id/pull/903. Added test to pass pipeline checks. 