### PR TITLE
Fix Ruby 2.7 keyword params deprecation warning

### DIFF
--- a/lib/friendly_id/history.rb
+++ b/lib/friendly_id/history.rb
@@ -72,7 +72,7 @@ method.
     # Configures the model instance to use the History add-on.
     def self.included(model_class)
       model_class.class_eval do
-        has_many :slugs, -> {order(id: :desc)}, {
+        has_many :slugs, -> {order(id: :desc)}, **{
           :as         => :sluggable,
           :dependent  => @friendly_id_config.dependent_value,
           :class_name => Slug.to_s


### PR DESCRIPTION
This fixes the following warnings that are printed when using friendly_id with Ruby 2.7.1:

Using friendly_id @ master:

```
friendly_id-984dac788d10/lib/friendly_id/history.rb:75: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
rails-370188aea03f/activerecord/lib/active_record/associations.rb:1370: warning: The called method `has_many' is defined here
```

Using this PR, no warnings are printed.