### PR TITLE
Fix mysql jobs in CI build matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
         ruby-version: ${{ matrix.ruby }}
         version: ${{ matrix.ruby }}
     - uses: actions/checkout@v1
-    - run: sudo apt-get update && sudo apt-get install libpq-dev postgresql-client libmysqlclient-dev libsqlite3-dev -y
+    - run: sudo apt-get update && sudo apt-get install libpq-dev postgresql-client libmysqlclient-dev mysql-client libsqlite3-dev -y
     - id: cache-bundler
       uses: actions/cache@v1
       with:
@@ -52,4 +52,9 @@ jobs:
         image: postgres:11.5
         ports: ["5432:5432"]
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
-
+      mysql:
+        image: mysql:5.7
+        ports: ["3306:3306"]
+        options: --health-cmd "mysqladmin ping" --health-interval 10s --health-timeout 5s --health-retries 5
+        env:
+          MYSQL_ROOT_PASSWORD: root

--- a/Rakefile
+++ b/Rakefile
@@ -71,7 +71,7 @@ namespace :db do
     driver = FriendlyId::Test::Database.driver
     config = FriendlyId::Test::Database.config[driver]
     commands = {
-      "mysql"    => "mysql -u #{config['username']} --password=#{config['password']} -e 'create database #{config["database"]};' >/dev/null",
+      "mysql"    => "mysql -h #{config['host']} -P #{config['port']} -u #{config['username']} --password=#{config['password']} -e 'create database #{config["database"]};' >/dev/null",
       "postgres" => "psql -c 'create database #{config['database']};' -U #{config['username']} >/dev/null"
     }
     %x{#{commands[driver] || true}}
@@ -83,7 +83,7 @@ namespace :db do
     driver = FriendlyId::Test::Database.driver
     config = FriendlyId::Test::Database.config[driver]
     commands = {
-      "mysql"    => "mysql -u #{config['username']} --password=#{config['password']} -e 'drop database #{config["database"]};' >/dev/null",
+      "mysql"    => "mysql -h #{config['host']} -P #{config['port']} -u #{config['username']} --password=#{config['password']} -e 'drop database #{config["database"]};' >/dev/null",
       "postgres" => "psql -c 'drop database #{config['database']};' -U #{config['username']} >/dev/null"
     }
     %x{#{commands[driver] || true}}

--- a/test/databases.yml
+++ b/test/databases.yml
@@ -3,7 +3,8 @@ mysql:
   database: friendly_id_test
   username: root
   password: <%= ENV['MYSQL_PASSWORD'] %>
-  hostname: localhost
+  host: 127.0.0.1
+  port: 3306
   encoding: utf8
 
 postgres:


### PR DESCRIPTION
The mysql jobs are failing in CI. It seems this is because there is no mysql service running. Fix by adding a mysql service to the CI config.