### PR TITLE
Fix "unknown column" exception

### DIFF
--- a/lib/friendly_id/sequentially_slugged.rb
+++ b/lib/friendly_id/sequentially_slugged.rb
@@ -7,11 +7,13 @@ module FriendlyId
     def resolve_friendly_id_conflict(candidate_slugs)
       candidate = candidate_slugs.first
       return if candidate.nil?
+
+      base_class, slug_column = slug_base_class_and_column
       SequentialSlugCalculator.new(scope_for_slug_generator,
                                   candidate,
-                                  friendly_id_config.slug_column,
+                                  slug_column,
                                   friendly_id_config.sequence_separator,
-                                  slug_base_class).next_slug
+                                  base_class).next_slug
     end
 
     class SequentialSlugCalculator
@@ -76,11 +78,11 @@ module FriendlyId
 
     private
 
-    def slug_base_class
+    def slug_base_class_and_column
       if friendly_id_config.uses?(:history)
-        Slug
+        [Slug, :slug]
       else
-        self.class.base_class
+        [self.class.base_class, friendly_id_config.slug_column]
       end
     end
   end

--- a/lib/friendly_id/sequentially_slugged.rb
+++ b/lib/friendly_id/sequentially_slugged.rb
@@ -8,12 +8,13 @@ module FriendlyId
       candidate = candidate_slugs.first
       return if candidate.nil?
 
-      base_class, slug_column = slug_base_class_and_column
-      SequentialSlugCalculator.new(scope_for_slug_generator,
-                                  candidate,
-                                  slug_column,
-                                  friendly_id_config.sequence_separator,
-                                  base_class).next_slug
+      SequentialSlugCalculator.new(
+        scope_for_slug_generator,
+        candidate,
+        slug_column,
+        friendly_id_config.sequence_separator,
+        slug_base_class
+      ).next_slug
     end
 
     class SequentialSlugCalculator
@@ -78,11 +79,19 @@ module FriendlyId
 
     private
 
-    def slug_base_class_and_column
+    def slug_base_class
       if friendly_id_config.uses?(:history)
-        [Slug, :slug]
+        Slug
       else
-        [self.class.base_class, friendly_id_config.slug_column]
+        self.class.base_class
+      end
+    end
+
+    def slug_column
+      if friendly_id_config.uses?(:history)
+        :slug
+      else
+        friendly_id_config.slug_column
       end
     end
   end

--- a/test/sequentially_slugged_test.rb
+++ b/test/sequentially_slugged_test.rb
@@ -158,6 +158,21 @@ class SequentiallySluggedTestWithHistory < TestCaseClass
       assert_equal 'test-name-3', record3.slug
     end
   end
+
+  test "should cope with strange column names" do
+    Journalist = Class.new(ActiveRecord::Base) do
+      extend FriendlyId
+      friendly_id :name, :use => [:sequentially_slugged, :history], :slug_column => "strange name"
+    end
+
+    transaction do
+      record_1 = Journalist.create! name: "Julian Assange"
+      record_2 = Journalist.create! name: "Julian Assange"
+
+      assert_equal 'julian-assange', record_1.attributes["strange name"]
+      assert_equal 'julian-assange-2', record_2.attributes["strange name"]
+    end
+  end
 end
 
 class City < ActiveRecord::Base


### PR DESCRIPTION
When custom `slug_column` is used along with `history` and
`sequentially_slugged` modules, wrong query was being formed on `Slug`
model.

Query being made - `select friendly_id_slugs."strange name" from artists`
Query which should be made - `select friendly_id_slugs.slug from artists`

This commit fixes it to use default `slug` column in such case.