### PR TITLE
Generating slug when validation is skipped

### DIFF
--- a/lib/friendly_id/slugged.rb
+++ b/lib/friendly_id/slugged.rb
@@ -248,6 +248,7 @@ Github issue](https://github.com/norman/friendly_id/issues/185) for discussion.
         defaults[:sequence_separator] ||= '-'
       end
       model_class.before_validation :set_slug
+      model_class.before_save :set_slug
       model_class.after_validation :unset_slug_if_invalid
     end
 

--- a/test/slugged_test.rb
+++ b/test/slugged_test.rb
@@ -479,6 +479,37 @@ class FailedValidationAfterUpdateRegressionTest < TestCaseClass
 
 end
 
+# https://github.com/norman/friendly_id/issues/947
+class GeneratingSlugWithValidationSkippedTest < TestCaseClass
+
+  include FriendlyId::Test
+
+  class Journalist < ActiveRecord::Base
+    extend FriendlyId
+    friendly_id :name, :use => :slugged
+  end
+
+  test "should generate slug when skipping validation" do
+    transaction do
+      m1 = Journalist.new
+      m1.name = 'Bob Timesletter'
+      m1.save(validate: false)
+      assert_equal 'bob-timesletter', m1.slug
+    end
+  end
+
+  test "should generate slug when #valid? called" do
+    transaction do
+      m1 = Journalist.new
+      m1.name = 'Bob Timesletter'
+      m1.valid?
+      m1.save(validate: false)
+      assert_equal 'bob-timesletter', m1.slug
+    end
+  end
+
+end
+
 class ToParamTest < TestCaseClass
 
   include FriendlyId::Test


### PR DESCRIPTION
This opens the change up for discussion and continuous integration.

Currently, this change brings in a failing test by @vfonic so that we can
get it passing.