### PR TITLE
Add `parse_friendly_id` to make slug finder downcase opt-in

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,8 @@ suggestions, ideas and improvements to FriendlyId.
 
 ## Unreleased
 
+* Revert "Make `first_by_friendly_id` case insensitive using `downcase`" ([#951](https://github.com/norman/friendly_id/pull/951))
+
 ## 5.4.1 (2020-11-06)
 
 * Fix unexpected `:slug` error on valid, unpersisted model ([#952](https://github.com/norman/friendly_id/pull/952))

--- a/lib/friendly_id/finder_methods.rb
+++ b/lib/friendly_id/finder_methods.rb
@@ -59,7 +59,7 @@ module FriendlyId
     end
 
     def first_by_friendly_id(id)
-      find_by(friendly_id_config.query_field => id.downcase)
+      find_by(friendly_id_config.query_field => id)
     end
 
     def raise_not_found_exception(id)

--- a/lib/friendly_id/finder_methods.rb
+++ b/lib/friendly_id/finder_methods.rb
@@ -20,8 +20,8 @@ module FriendlyId
       return super if args.count != 1 || id.unfriendly_id?
       first_by_friendly_id(id).tap {|result| return result unless result.nil?}
       return super if potential_primary_key?(id)
-      raise_not_found_exception id
-      
+
+      raise_not_found_exception(id)
     end
 
     # Returns true if a record with the given id exists.
@@ -39,7 +39,7 @@ module FriendlyId
     end
 
     def exists_by_friendly_id?(id)
-      where(friendly_id_config.query_field => id).exists?
+      where(friendly_id_config.query_field => parse_friendly_id(id)).exists?
     end
 
     private
@@ -59,14 +59,47 @@ module FriendlyId
     end
 
     def first_by_friendly_id(id)
-      find_by(friendly_id_config.query_field => id)
+      find_by(friendly_id_config.query_field => parse_friendly_id(id))
+    end
+
+    # Parse the given value to make it suitable for use as a slug according to
+    # your application's rules.
+    #
+    # This method is not intended to be invoked directly; FriendlyId uses it
+    # internally to process a slug into string to use as a finder.
+    #
+    # However, if FriendlyId's default slug parsing doesn't suit your needs,
+    # you can override this method in your model class to control exactly how
+    # slugs are generated.
+    #
+    # ### Example
+    #
+    #     class Person < ActiveRecord::Base
+    #       extend FriendlyId
+    #       friendly_id :name_and_location
+    #
+    #       def name_and_location
+    #         "#{name} from #{location}"
+    #       end
+    #
+    #       # Use default slug, but lower case
+    #       # If `id` is "Jane-Doe" or "JANE-DOE", this finds data by "jane-doe"
+    #       def parse_friendly_id(slug)
+    #         super.downcase
+    #       end
+    #     end
+    #
+    # @param [#to_s] value The slug to be parsed.
+    # @return The parsed slug, which is not modified by default.
+    def parse_friendly_id(value)
+      value
     end
 
     def raise_not_found_exception(id)
       message = "can't find record with friendly id: #{id.inspect}"
-      if ActiveRecord.version < Gem::Version.create('5.0') then 
+      if ActiveRecord.version < Gem::Version.create('5.0')
         raise ActiveRecord::RecordNotFound.new(message)
-      else 
+      else
         raise ActiveRecord::RecordNotFound.new(message, name, friendly_id_config.query_field, id)
       end
     end

--- a/test/finders_test.rb
+++ b/test/finders_test.rb
@@ -26,28 +26,4 @@ class Finders < TestCaseClass
       assert model_class.existing.find(record.friendly_id)
     end
   end
-
-  test 'should find capitalized records with finders as class methods' do
-    with_instance_of(model_class) do |record|
-      assert model_class.find(record.friendly_id.capitalize)
-    end
-  end
-
-  test 'should find capitalized records with finders on relations' do
-    with_instance_of(model_class) do |record|
-      assert model_class.existing.find(record.friendly_id.capitalize)
-    end
-  end
-
-  test 'should find upcased records with finders as class methods' do
-    with_instance_of(model_class) do |record|
-      assert model_class.find(record.friendly_id.upcase)
-    end
-  end
-
-  test 'should find upcased records with finders on relations' do
-    with_instance_of(model_class) do |record|
-      assert model_class.existing.find(record.friendly_id.upcase)
-    end
-  end
 end


### PR DESCRIPTION
In #787 we merged a change which found slugs by `id.downcase` by
default, but this has understandably caused issues for other users of
FriendlyId who don't want to do this.

This reverts that change and introduces a new method, 
`parse_friendly_id`, which can be overridden similar to 
`normalize_friendly_id`.  

Instead of being used for slug generation, `parse_friendly_id` is used
for parsing incoming slugs.

Fixes #950 