### PR TITLE
CI: Use setup-ruby at v1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     name: ${{ matrix.ruby }} ${{ matrix.database }} rails-${{ matrix.gemfile }}
     steps:
-    - uses: actions/setup-ruby@v1.0.0
+    - uses: actions/setup-ruby@v1
       with:
         architecture: ${{ matrix.architecture }}
         ruby-version: ${{ matrix.ruby }}


### PR DESCRIPTION
It fixes the CI after a moderate security vulnerability.

https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/