### PR TITLE
Example of to_params not generating expected data.

### DIFF
--- a/test/slugged_test.rb
+++ b/test/slugged_test.rb
@@ -531,7 +531,7 @@ class ToParamTest < TestCaseClass
       journalist = Journalist.new :name => 'Clark Kent', :active => true
       assert journalist.save
       journalist.name = 'Superman'
-      journalist.slug = nil
+      journalist.slug = 'no-so-superman'
       journalist.active = nil
       refute journalist.save
       assert_equal 'superman', journalist.to_param
@@ -543,7 +543,7 @@ class ToParamTest < TestCaseClass
       journalist = Journalist.new :name => 'Clark Kent', :active => true
       assert journalist.save
       journalist.name = 'x'
-      journalist.slug = nil
+      journalist.slug = 'tots-not-clark-kent'
       journalist.active = nil
       refute journalist.save
       assert_equal 'clark-kent', journalist.to_param


### PR DESCRIPTION
Dearest reviewer,

Details in issue https://github.com/norman/friendly_id/issues/959

This is an example of the to_param issue from the issue above. Versions before the 5.1 change would return the old slug data.

Thanks