### PR TITLE
SimpleI18n: Handle regional locales

### DIFF
--- a/lib/friendly_id/simple_i18n.rb
+++ b/lib/friendly_id/simple_i18n.rb
@@ -11,9 +11,9 @@ FriendlyId.
 
 In order to use this module, your model must have a slug column for each locale.
 By default FriendlyId looks for columns named, for example, "slug_en",
-"slug_es", etc. The first part of the name can be configured by passing the
-`:slug_column` option if you choose. Note that the column for the default locale
-must also include the locale in its name.
+"slug_es", "slug_pt_br", etc. The first part of the name can be configured by
+passing the `:slug_column` option if you choose. Note that the column for the
+default locale must also include the locale in its name.
 
 This module is most suitable to applications that need to support few locales.
 If you need to support two or more locales, you may wish to use the
@@ -26,10 +26,12 @@ friendly_id_globalize gem instead.
         t.string :title
         t.string :slug_en
         t.string :slug_es
+        t.string :slug_pt_br
         t.text   :body
       end
       add_index :posts, :slug_en
       add_index :posts, :slug_es
+      add_index :posts, :slug_pt_br
     end
 
 ### Finds
@@ -40,6 +42,8 @@ Finds will take into consideration the current locale:
     Post.friendly.find("la-guerra-de-las-galaxias")
     I18n.locale = :en
     Post.friendly.find("star-wars")
+    I18n.locale = :"pt-BR"
+    Post.friendly.find("guerra-das-estrelas")
 
 To find a slug by an explicit locale, perform the find inside a block
 passed to I18n's `with_locale` method:
@@ -98,7 +102,13 @@ current locale:
 
     module Configuration
       def slug_column
-        "#{super}_#{I18n.locale}"
+        "#{super}_#{locale_suffix}"
+      end
+
+      private
+
+      def locale_suffix
+        I18n.locale.to_s.underscore
       end
     end
   end

--- a/test/schema.rb
+++ b/test/schema.rb
@@ -69,6 +69,7 @@ module FriendlyId
           add_column :journalists, "slug_en", :string
           add_column :journalists, "slug_es", :string
           add_column :journalists, "slug_de", :string
+          add_column :journalists, "slug_fr_ca", :string
 
           # This will be used to test relationships
           add_column :books, :author_id, :integer

--- a/test/simple_i18n_test.rb
+++ b/test/simple_i18n_test.rb
@@ -15,12 +15,16 @@ class SimpleI18nTest < TestCaseClass
   test "friendly_id should return the current locale's slug" do
     journalist = Journalist.new(:name => "John Doe")
     journalist.slug_es = "juan-fulano"
+    journalist.slug_fr_ca = "jean-dupont"
     journalist.valid?
     I18n.with_locale(I18n.default_locale) do
       assert_equal "john-doe", journalist.friendly_id
     end
     I18n.with_locale(:es) do
       assert_equal "juan-fulano", journalist.friendly_id
+    end
+    I18n.with_locale(:"fr-CA") do
+      assert_equal "jean-dupont", journalist.friendly_id
     end
   end
 
@@ -111,6 +115,12 @@ class SimpleI18nTest < TestCaseClass
     test "should add locale to slug column for a non-default locale" do
       I18n.with_locale :es do
         assert_equal "slug_es", Journalist.friendly_id_config.slug_column
+      end
+    end
+
+    test "should add locale to slug column for a locale with a region subtag" do
+      I18n.with_locale :"fr-CA" do
+        assert_equal "slug_fr_ca", Journalist.friendly_id_config.slug_column
       end
     end
 


### PR DESCRIPTION
It defines how to use slug columns for locales with region subtags.

This could result in a breaking change for people using column names like `title_pt-BR`. Here I try to be explicit about and define how to use subtags, which we currently don't.