### PR TITLE
Extract sequential_slug_calculator to sequentially_slugged/calculator

### DIFF
--- a/lib/friendly_id/sequentially_slugged.rb
+++ b/lib/friendly_id/sequentially_slugged.rb
@@ -1,3 +1,5 @@
+require_relative 'sequentially_slugged/calculator'
+
 module FriendlyId
   module SequentiallySlugged
     def self.setup(model_class)
@@ -8,73 +10,13 @@ module FriendlyId
       candidate = candidate_slugs.first
       return if candidate.nil?
 
-      SequentialSlugCalculator.new(
+      Calculator.new(
         scope_for_slug_generator,
         candidate,
         slug_column,
         friendly_id_config.sequence_separator,
         slug_base_class
       ).next_slug
-    end
-
-    class SequentialSlugCalculator
-      attr_accessor :scope, :slug, :slug_column, :sequence_separator
-
-      def initialize(scope, slug, slug_column, sequence_separator, base_class)
-        @scope = scope
-        @slug = slug
-        table_name = scope.connection.quote_table_name(base_class.arel_table.name)
-        @slug_column = "#{table_name}.#{scope.connection.quote_column_name(slug_column)}"
-        @sequence_separator = sequence_separator
-      end
-
-      def next_slug
-        slug + sequence_separator + next_sequence_number.to_s
-      end
-
-    private
-
-      def next_sequence_number
-        last_sequence_number ? last_sequence_number + 1 : 2
-      end
-
-      def last_sequence_number
-        regexp = /#{slug}#{sequence_separator}(\d+)\z/
-        # Reject slug_conflicts that doesn't come from the first_candidate
-        # Map all sequence numbers and take the maximum
-        slug_conflicts.reject{ |slug_conflict| !regexp.match(slug_conflict) }.map do |slug_conflict|
-          regexp.match(slug_conflict)[1].to_i
-        end.max
-      end
-
-      def slug_conflicts
-        scope.
-          where(conflict_query, slug, sequential_slug_matcher).
-          order(Arel.sql(ordering_query)).pluck(Arel.sql(slug_column))
-      end
-
-      def conflict_query
-        base = "#{slug_column} = ? OR #{slug_column} LIKE ?"
-        # Awful hack for SQLite3, which does not pick up '\' as the escape character
-        # without this.
-        base << " ESCAPE '\\'" if scope.connection.adapter_name =~ /sqlite/i
-        base
-      end
-
-      def sequential_slug_matcher
-        # Underscores (matching a single character) and percent signs (matching
-        # any number of characters) need to be escaped. While this looks like
-        # an excessive number of backslashes, it is correct.
-        "#{slug}#{sequence_separator}".gsub(/[_%]/, '\\\\\&') + '%'
-      end
-
-      # Return the unnumbered (shortest) slug first, followed by the numbered ones
-      # in ascending order.
-      def ordering_query
-        length_command = "LENGTH"
-        length_command = "LEN" if scope.connection.adapter_name =~ /sqlserver/i
-        "#{length_command}(#{slug_column}) ASC, #{slug_column} ASC"
-      end
     end
 
     private

--- a/lib/friendly_id/sequentially_slugged/calculator.rb
+++ b/lib/friendly_id/sequentially_slugged/calculator.rb
@@ -41,9 +41,7 @@ module FriendlyId
       # Return the unnumbered (shortest) slug first, followed by the numbered ones
       # in ascending order.
       def ordering_query
-        length_command = "LENGTH"
-        length_command = "LEN" if scope.connection.adapter_name =~ /sqlserver/i
-        "#{length_command}(#{slug_column}) ASC, #{slug_column} ASC"
+        "#{sql_length}(#{slug_column}) ASC, #{slug_column} ASC"
       end
 
       def regexp
@@ -61,6 +59,10 @@ module FriendlyId
         scope.
           where(conflict_query, slug, sequential_slug_matcher).
           order(Arel.sql(ordering_query)).pluck(Arel.sql(slug_column))
+      end
+
+      def sql_length
+        scope.connection.adapter_name =~ /sqlserver/i ? 'LEN' : 'LENGTH'
       end
     end
   end

--- a/lib/friendly_id/sequentially_slugged/calculator.rb
+++ b/lib/friendly_id/sequentially_slugged/calculator.rb
@@ -1,0 +1,63 @@
+module FriendlyId
+  module SequentiallySlugged
+    class Calculator
+      attr_accessor :scope, :slug, :slug_column, :sequence_separator
+
+      def initialize(scope, slug, slug_column, sequence_separator, base_class)
+        @scope = scope
+        @slug = slug
+        table_name = scope.connection.quote_table_name(base_class.arel_table.name)
+        @slug_column = "#{table_name}.#{scope.connection.quote_column_name(slug_column)}"
+        @sequence_separator = sequence_separator
+      end
+
+      def next_slug
+        slug + sequence_separator + next_sequence_number.to_s
+      end
+
+      private
+
+      def next_sequence_number
+        last_sequence_number ? last_sequence_number + 1 : 2
+      end
+
+      def last_sequence_number
+        regexp = /#{slug}#{sequence_separator}(\d+)\z/
+        # Reject slug_conflicts that doesn't come from the first_candidate
+        # Map all sequence numbers and take the maximum
+        slug_conflicts
+          .reject { |slug_conflict| !regexp.match(slug_conflict) }
+          .map { |slug_conflict| regexp.match(slug_conflict)[1].to_i }.max
+      end
+
+      def slug_conflicts
+        scope.
+          where(conflict_query, slug, sequential_slug_matcher).
+          order(Arel.sql(ordering_query)).pluck(Arel.sql(slug_column))
+      end
+
+      def conflict_query
+        base = "#{slug_column} = ? OR #{slug_column} LIKE ?"
+        # Awful hack for SQLite3, which does not pick up '\' as the escape character
+        # without this.
+        base << " ESCAPE '\\'" if scope.connection.adapter_name =~ /sqlite/i
+        base
+      end
+
+      def sequential_slug_matcher
+        # Underscores (matching a single character) and percent signs (matching
+        # any number of characters) need to be escaped. While this looks like
+        # an excessive number of backslashes, it is correct.
+        "#{slug}#{sequence_separator}".gsub(/[_%]/, '\\\\\&') + '%'
+      end
+
+      # Return the unnumbered (shortest) slug first, followed by the numbered ones
+      # in ascending order.
+      def ordering_query
+        length_command = "LENGTH"
+        length_command = "LEN" if scope.connection.adapter_name =~ /sqlserver/i
+        "#{length_command}(#{slug_column}) ASC, #{slug_column} ASC"
+      end
+    end
+  end
+end


### PR DESCRIPTION
While looking at the code, I got confused about variable names inside 
`SequentiallySlugged` because there was another class nested inside the
file: `SequentialSlugCalculator`.

To avoid this confusion, I've extracted this inner class to another
file: `lib/friendly_id/sequentially_slugged/calculator.rb`.