### PR TITLE
Don't call upstream if nothing found via friendly ID search

### DIFF
--- a/lib/friendly_id/finder_methods.rb
+++ b/lib/friendly_id/finder_methods.rb
@@ -28,7 +28,7 @@ module FriendlyId
     def exists?(conditions = :none)
       return super if conditions.unfriendly_id?
       return true if exists_by_friendly_id?(conditions)
-      super
+      false
     end
 
     # Finds exclusively by the friendly id, completely bypassing original


### PR DESCRIPTION
Prevent false positives when friendly ID doesn't match