### PR TITLE
Add Ruby 3.0 to CI test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,12 +10,12 @@ jobs:
     strategy:
       matrix:
         database: [ mysql, postgresql ]
-        gemfile: [ 6.0, 5.2 ]
-        ruby: [ 2.5, 2.6, 2.7, 3.0 ]
+        gemfile: [ '6.0', '5.2' ]
+        ruby: [ '2.5', '2.6', '2.7', '3.0' ]
         exclude:
           # excludes ruby 3 with Rails 5.2
-          - ruby: 3.0
-            gemfile: 5.2
+          - ruby: '3.0'
+            gemfile: '5.2'
       fail-fast: false
     runs-on: ubuntu-latest
     name: ${{ matrix.ruby }} ${{ matrix.database }} rails-${{ matrix.gemfile }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,12 @@ jobs:
     strategy:
       matrix:
         database: [ mysql, postgresql ]
-        gemfile: [ '6.0', '5.2' ]
+        gemfile: [ 6.0, 5.2 ]
         ruby: [ 2.5, 2.6, 2.7, 3.0 ]
+        exclude:
+          # excludes ruby 3 with Rails 5.2
+          - ruby: 3.0
+            gemfile: 5.2
       fail-fast: false
     runs-on: ubuntu-latest
     name: ${{ matrix.ruby }} ${{ matrix.database }} rails-${{ matrix.gemfile }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         database: [ mysql, postgresql ]
         gemfile: [ '6.0', '5.2' ]
-        ruby: [ '2.7', '2.6', '2.5' ]
+        ruby: [ 2.5, 2.6, 2.7, 3.0 ]
       fail-fast: false
     runs-on: ubuntu-latest
     name: ${{ matrix.ruby }} ${{ matrix.database }} rails-${{ matrix.gemfile }}

--- a/Gemfile
+++ b/Gemfile
@@ -19,9 +19,4 @@ group :development, :test do
     gem 'sqlite3'
     gem 'redcarpet'
   end
-
-  platforms :rbx do
-    gem 'rubysl', '~> 2.0'
-    gem 'rubinius-developer_tools'
-  end
 end

--- a/gemfiles/Gemfile.rails-5.2.rb
+++ b/gemfiles/Gemfile.rails-5.2.rb
@@ -19,9 +19,4 @@ group :development, :test do
     gem 'pg'
     gem 'redcarpet'
   end
-
-  platforms :rbx do
-    gem 'rubysl', '~> 2.0'
-    gem 'rubinius-developer_tools'
-  end
 end

--- a/gemfiles/Gemfile.rails-6.0.rb
+++ b/gemfiles/Gemfile.rails-6.0.rb
@@ -19,9 +19,4 @@ group :development, :test do
     gem 'pg'
     gem 'redcarpet'
   end
-
-  platforms :rbx do
-    gem 'rubysl', '~> 2.0'
-    gem 'rubinius-developer_tools'
-  end
 end


### PR DESCRIPTION
Ruby 3.0 has been out for a while and it makes sense to test FriendlyId
with it on CI.