### PR TITLE
Add Rails 6.1 to CI test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         database: [ mysql, postgresql ]
-        gemfile: [ '6.0', '5.2' ]
+        gemfile: [ '6.1', '6.0', '5.2' ]
         ruby: [ '2.5', '2.6', '2.7', '3.0' ]
         exclude:
           # excludes ruby 3 with Rails 5.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,6 @@ jobs:
         gemfile: [ '6.1', '6.0', '5.2' ]
         ruby: [ '2.5', '2.6', '2.7', '3.0' ]
         exclude:
-          # excludes ruby 3 with Rails 5.2
           - ruby: '3.0'
             gemfile: '5.2'
       fail-fast: false

--- a/gemfiles/Gemfile.rails-6.1.rb
+++ b/gemfiles/Gemfile.rails-6.1.rb
@@ -1,0 +1,22 @@
+source 'https://rubygems.org'
+
+gemspec path: '../'
+
+gem 'activerecord', '~> 6.1.4'
+gem 'railties', '~> 6.1.4'
+
+# Database Configuration
+group :development, :test do
+  platforms :jruby do
+    gem 'activerecord-jdbcmysql-adapter', '~> 61.0'
+    gem 'activerecord-jdbcpostgresql-adapter', '~> 61.0'
+    gem 'kramdown'
+  end
+
+  platforms :ruby, :rbx do
+    gem 'sqlite3'
+    gem 'mysql2'
+    gem 'pg'
+    gem 'redcarpet'
+  end
+end


### PR DESCRIPTION
Rails 6.1 is the latest stable release of Rails, so it makes sense to
use CI to test that we're compatible with it.