### PR TITLE
Adopt standard syntax

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,22 +1,23 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 gemspec
 
-gem 'rake'
+gem "standard"
+gem "rake"
 
 group :development, :test do
   platforms :ruby do
-    gem 'byebug'
-    gem 'pry'
+    gem "byebug"
+    gem "pry"
   end
 
   platforms :jruby do
-    gem 'activerecord-jdbcsqlite3-adapter', '>= 1.3.0.beta2'
-    gem 'kramdown'
+    gem "activerecord-jdbcsqlite3-adapter", ">= 1.3.0.beta2"
+    gem "kramdown"
   end
 
   platforms :ruby, :rbx do
-    gem 'sqlite3'
-    gem 'redcarpet'
+    gem "sqlite3"
+    gem "redcarpet"
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,107 +1,104 @@
 require "rubygems"
 require "rake/testtask"
 
-task :default => :test
+task default: :test
 
 task :load_path do
-  %w(lib test).each do |path|
+  %w[lib test].each do |path|
     $LOAD_PATH.unshift(File.expand_path("../#{path}", __FILE__))
   end
 end
 
 Rake::TestTask.new do |t|
   t.libs << "test"
-  t.test_files = FileList['test/*_test.rb']
+  t.test_files = FileList["test/*_test.rb"]
   t.verbose = true
 end
 
 desc "Remove temporary files"
 task :clean do
-  %x{rm -rf *.gem doc pkg coverage}
-  %x{rm -f `find . -name '*.rbc'`}
+  `rm -rf *.gem doc pkg coverage`
+  %x(rm -f `find . -name '*.rbc'`)
 end
 
 desc "Build the gem"
 task :gem do
-  %x{gem build friendly_id.gemspec}
+  `gem build friendly_id.gemspec`
 end
 
 desc "Build YARD documentation"
 task :yard do
-  puts %x{bundle exec yard}
+  puts `bundle exec yard`
 end
 
 desc "Run benchmarks"
-task :bench => :load_path do
+task bench: :load_path do
   require File.expand_path("../bench", __FILE__)
 end
 
 desc "Run benchmarks on finders"
-task :bench_finders => :load_path do
+task bench_finders: :load_path do
   require File.expand_path("../test/benchmarks/finders", __FILE__)
 end
 
 desc "Run benchmarks on ObjectUtils"
-task :bench_object_utils => :load_path do
+task bench_object_utils: :load_path do
   require File.expand_path("../test/benchmarks/object_utils", __FILE__)
 end
 
 desc "Generate Guide.md"
 task :guide do
-  load File.expand_path('../guide.rb', __FILE__)
+  load File.expand_path("../guide.rb", __FILE__)
 end
 
 namespace :test do
-
   desc "Run each test class in a separate process"
   task :isolated do
     dir = File.expand_path("../test", __FILE__)
     Dir["#{dir}/*_test.rb"].each do |test|
       puts "Running #{test}:"
-      puts %x{ruby -Ilib -Itest #{test}}
+      puts `ruby -Ilib -Itest #{test}`
     end
   end
 end
 
 namespace :db do
-
   desc "Create the database"
-  task :create => :load_path do
+  task create: :load_path do
     require "helper"
     driver = FriendlyId::Test::Database.driver
     config = FriendlyId::Test::Database.config[driver]
     commands = {
-      "mysql"    => "mysql -h #{config['host']} -P #{config['port']} -u #{config['username']} --password=#{config['password']} -e 'create database #{config["database"]};' >/dev/null",
-      "postgres" => "psql -c 'create database #{config['database']};' -U #{config['username']} >/dev/null"
+      "mysql" => "mysql -h #{config["host"]} -P #{config["port"]} -u #{config["username"]} --password=#{config["password"]} -e 'create database #{config["database"]};' >/dev/null",
+      "postgres" => "psql -c 'create database #{config["database"]};' -U #{config["username"]} >/dev/null"
     }
-    %x{#{commands[driver] || true}}
+    `#{commands[driver] || true}`
   end
 
   desc "Drop the database"
-  task :drop => :load_path do
+  task drop: :load_path do
     require "helper"
     driver = FriendlyId::Test::Database.driver
     config = FriendlyId::Test::Database.config[driver]
     commands = {
-      "mysql"    => "mysql -h #{config['host']} -P #{config['port']} -u #{config['username']} --password=#{config['password']} -e 'drop database #{config["database"]};' >/dev/null",
-      "postgres" => "psql -c 'drop database #{config['database']};' -U #{config['username']} >/dev/null"
+      "mysql" => "mysql -h #{config["host"]} -P #{config["port"]} -u #{config["username"]} --password=#{config["password"]} -e 'drop database #{config["database"]};' >/dev/null",
+      "postgres" => "psql -c 'drop database #{config["database"]};' -U #{config["username"]} >/dev/null"
     }
-    %x{#{commands[driver] || true}}
+    `#{commands[driver] || true}`
   end
 
   desc "Set up the database schema"
-  task :up => :load_path do
+  task up: :load_path do
     require "helper"
     FriendlyId::Test::Schema.up
   end
 
   desc "Drop and recreate the database schema"
-  task :reset => [:drop, :create]
-
+  task reset: [:drop, :create]
 end
 
-task :doc => :yard
+task doc: :yard
 
 task :docs do
-  sh %{git checkout gh-pages && rake doc && git checkout @{-1}}
+  sh %(git checkout gh-pages && rake doc && git checkout @{-1})
 end

--- a/friendly_id.gemspec
+++ b/friendly_id.gemspec
@@ -1,39 +1,38 @@
-# encoding: utf-8
 require File.expand_path("../lib/friendly_id/version", __FILE__)
 
 Gem::Specification.new do |s|
-  s.name              = "friendly_id"
-  s.version           = FriendlyId::VERSION
-  s.authors           = ["Norman Clarke", "Philip Arndt"]
-  s.email             = ["norman@njclarke.com", "p@arndt.io"]
-  s.homepage          = "https://github.com/norman/friendly_id"
-  s.summary           = "A comprehensive slugging and pretty-URL plugin."
-  s.files             = `git ls-files`.split("\n")
-  s.test_files        = `git ls-files -- {test}/*`.split("\n")
-  s.require_paths     = ["lib"]
-  s.license           = 'MIT'
+  s.name = "friendly_id"
+  s.version = FriendlyId::VERSION
+  s.authors = ["Norman Clarke", "Philip Arndt"]
+  s.email = ["norman@njclarke.com", "p@arndt.io"]
+  s.homepage = "https://github.com/norman/friendly_id"
+  s.summary = "A comprehensive slugging and pretty-URL plugin."
+  s.files = `git ls-files`.split("\n")
+  s.test_files = `git ls-files -- {test}/*`.split("\n")
+  s.require_paths = ["lib"]
+  s.license = "MIT"
 
-  s.required_ruby_version = '>= 2.1.0'
+  s.required_ruby_version = ">= 2.1.0"
 
-  s.add_dependency 'activerecord', '>= 4.0.0'
+  s.add_dependency "activerecord", ">= 4.0.0"
 
-  s.add_development_dependency 'coveralls'
-  s.add_development_dependency 'railties', '>= 4.0'
-  s.add_development_dependency 'minitest', '~> 5.3'
-  s.add_development_dependency 'mocha', '~> 1.1'
-  s.add_development_dependency 'yard'
-  s.add_development_dependency 'i18n'
-  s.add_development_dependency 'ffaker'
-  s.add_development_dependency 'simplecov'
+  s.add_development_dependency "coveralls"
+  s.add_development_dependency "railties", ">= 4.0"
+  s.add_development_dependency "minitest", "~> 5.3"
+  s.add_development_dependency "mocha", "~> 1.1"
+  s.add_development_dependency "yard"
+  s.add_development_dependency "i18n"
+  s.add_development_dependency "ffaker"
+  s.add_development_dependency "simplecov"
 
-  s.description = <<-EOM
-FriendlyId is the "Swiss Army bulldozer" of slugging and permalink plugins for
-Active Record. It lets you create pretty URLs and work with human-friendly
-strings as if they were numeric ids.
-EOM
+  s.description = <<~EOM
+    FriendlyId is the "Swiss Army bulldozer" of slugging and permalink plugins for
+    Active Record. It lets you create pretty URLs and work with human-friendly
+    strings as if they were numeric ids.
+  EOM
 
-  s.cert_chain = [File.expand_path('certs/parndt.pem', __dir__)]
-  if $PROGRAM_NAME =~ /gem\z/ && ARGV.include?('build') && ARGV.include?(__FILE__)
-    s.signing_key = File.expand_path('~/.ssh/gem-private_key.pem')
+  s.cert_chain = [File.expand_path("certs/parndt.pem", __dir__)]
+  if $PROGRAM_NAME.end_with?("gem") && ARGV.include?("build") && ARGV.include?(__FILE__)
+    s.signing_key = File.expand_path("~/.ssh/gem-private_key.pem")
   end
 end

--- a/gemfiles/Gemfile.rails-5.2.rb
+++ b/gemfiles/Gemfile.rails-5.2.rb
@@ -1,22 +1,22 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-gemspec path: '../'
+gemspec path: "../"
 
-gem 'activerecord', '~> 5.2.0'
-gem 'railties', '~> 5.2.0'
+gem "activerecord", "~> 5.2.0"
+gem "railties", "~> 5.2.0"
 
 # Database Configuration
 group :development, :test do
   platforms :jruby do
-    gem 'activerecord-jdbcmysql-adapter', '~> 51.1'
-    gem 'activerecord-jdbcpostgresql-adapter', '~> 51.1'
-    gem 'kramdown'
+    gem "activerecord-jdbcmysql-adapter", "~> 51.1"
+    gem "activerecord-jdbcpostgresql-adapter", "~> 51.1"
+    gem "kramdown"
   end
 
   platforms :ruby, :rbx do
-    gem 'sqlite3'
-    gem 'mysql2'
-    gem 'pg'
-    gem 'redcarpet'
+    gem "sqlite3"
+    gem "mysql2"
+    gem "pg"
+    gem "redcarpet"
   end
 end

--- a/gemfiles/Gemfile.rails-6.0.rb
+++ b/gemfiles/Gemfile.rails-6.0.rb
@@ -1,22 +1,22 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-gemspec path: '../'
+gemspec path: "../"
 
-gem 'activerecord', '~> 6.0.0'
-gem 'railties', '~> 6.0.0'
+gem "activerecord", "~> 6.0.0"
+gem "railties", "~> 6.0.0"
 
 # Database Configuration
 group :development, :test do
   platforms :jruby do
-    gem 'activerecord-jdbcmysql-adapter', '~> 51.1'
-    gem 'activerecord-jdbcpostgresql-adapter', '~> 51.1'
-    gem 'kramdown'
+    gem "activerecord-jdbcmysql-adapter", "~> 51.1"
+    gem "activerecord-jdbcpostgresql-adapter", "~> 51.1"
+    gem "kramdown"
   end
 
   platforms :ruby, :rbx do
-    gem 'sqlite3'
-    gem 'mysql2'
-    gem 'pg'
-    gem 'redcarpet'
+    gem "sqlite3"
+    gem "mysql2"
+    gem "pg"
+    gem "redcarpet"
   end
 end

--- a/gemfiles/Gemfile.rails-6.1.rb
+++ b/gemfiles/Gemfile.rails-6.1.rb
@@ -1,22 +1,22 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-gemspec path: '../'
+gemspec path: "../"
 
-gem 'activerecord', '~> 6.1.4'
-gem 'railties', '~> 6.1.4'
+gem "activerecord", "~> 6.1.4"
+gem "railties", "~> 6.1.4"
 
 # Database Configuration
 group :development, :test do
   platforms :jruby do
-    gem 'activerecord-jdbcmysql-adapter', '~> 61.0'
-    gem 'activerecord-jdbcpostgresql-adapter', '~> 61.0'
-    gem 'kramdown'
+    gem "activerecord-jdbcmysql-adapter", "~> 61.0"
+    gem "activerecord-jdbcpostgresql-adapter", "~> 61.0"
+    gem "kramdown"
   end
 
   platforms :ruby, :rbx do
-    gem 'sqlite3'
-    gem 'mysql2'
-    gem 'pg'
-    gem 'redcarpet'
+    gem "sqlite3"
+    gem "mysql2"
+    gem "pg"
+    gem "redcarpet"
   end
 end

--- a/guide.rb
+++ b/guide.rb
@@ -3,14 +3,14 @@
 # This script generates the Guide.md file included in the Yard docs.
 
 def comments_from path
-  path  = File.expand_path("../lib/friendly_id/#{path}", __FILE__)
+  path = File.expand_path("../lib/friendly_id/#{path}", __FILE__)
   match = File.read(path).match(/\n=begin(.*)\n=end/m)[1].to_s
-  match.split("\n").reject {|x| x =~ /^@/}.join("\n").strip
+  match.split("\n").reject { |x| x =~ /^@/ }.join("\n").strip
 end
 
-File.open(File.expand_path('../Guide.md', __FILE__), 'w:utf-8') do |guide|
-  ['../friendly_id.rb', 'base.rb', 'finders.rb', 'slugged.rb', 'history.rb',
-  'scoped.rb', 'simple_i18n.rb', 'reserved.rb'].each do |file|
+File.open(File.expand_path("../Guide.md", __FILE__), "w:utf-8") do |guide|
+  ["../friendly_id.rb", "base.rb", "finders.rb", "slugged.rb", "history.rb",
+    "scoped.rb", "simple_i18n.rb", "reserved.rb"].each do |file|
     guide.write comments_from file
     guide.write "\n"
   end

--- a/lib/friendly_id.rb
+++ b/lib/friendly_id.rb
@@ -1,55 +1,51 @@
-# encoding: utf-8
-require 'active_record'
+require "active_record"
 require "friendly_id/base"
 require "friendly_id/object_utils"
 require "friendly_id/configuration"
 require "friendly_id/finder_methods"
 
-=begin
-
+#
 ## About FriendlyId
-
-FriendlyId is an add-on to Ruby's Active Record that allows you to replace ids
-in your URLs with strings:
-
-    # without FriendlyId
-    http://example.com/states/4323454
-
-    # with FriendlyId
-    http://example.com/states/washington
-
-It requires few changes to your application code and offers flexibility,
-performance and a well-documented codebase.
-
+#
+# FriendlyId is an add-on to Ruby's Active Record that allows you to replace ids
+# in your URLs with strings:
+#
+#     # without FriendlyId
+#     http://example.com/states/4323454
+#
+#     # with FriendlyId
+#     http://example.com/states/washington
+#
+# It requires few changes to your application code and offers flexibility,
+# performance and a well-documented codebase.
+#
 ### Core Concepts
-
+#
 #### Slugs
-
-The concept of *slugs* is at the heart of FriendlyId.
-
-A slug is the part of a URL which identifies a page using human-readable
-keywords, rather than an opaque identifier such as a numeric id. This can make
-your application more friendly both for users and search engines.
-
+#
+# The concept of *slugs* is at the heart of FriendlyId.
+#
+# A slug is the part of a URL which identifies a page using human-readable
+# keywords, rather than an opaque identifier such as a numeric id. This can make
+# your application more friendly both for users and search engines.
+#
 #### Finders: Slugs Act Like Numeric IDs
-
-To the extent possible, FriendlyId lets you treat text-based identifiers like
-normal IDs. This means that you can perform finds with slugs just like you do
-with numeric ids:
-
-    Person.find(82542335)
-    Person.friendly.find("joe")
-
-=end
+#
+# To the extent possible, FriendlyId lets you treat text-based identifiers like
+# normal IDs. This means that you can perform finds with slugs just like you do
+# with numeric ids:
+#
+#     Person.find(82542335)
+#     Person.friendly.find("joe")
+#
 module FriendlyId
-
-  autoload :History,             "friendly_id/history"
-  autoload :Slug,                "friendly_id/slug"
-  autoload :SimpleI18n,          "friendly_id/simple_i18n"
-  autoload :Reserved,            "friendly_id/reserved"
-  autoload :Scoped,              "friendly_id/scoped"
-  autoload :Slugged,             "friendly_id/slugged"
-  autoload :Finders,             "friendly_id/finders"
+  autoload :History, "friendly_id/history"
+  autoload :Slug, "friendly_id/slug"
+  autoload :SimpleI18n, "friendly_id/simple_i18n"
+  autoload :Reserved, "friendly_id/reserved"
+  autoload :Scoped, "friendly_id/scoped"
+  autoload :Slugged, "friendly_id/slugged"
+  autoload :Finders, "friendly_id/finders"
   autoload :SequentiallySlugged, "friendly_id/sequentially_slugged"
 
   # FriendlyId takes advantage of `extended` to do basic model setup, primarily
@@ -77,7 +73,7 @@ module FriendlyId
   def self.extended(model_class)
     return if model_class.respond_to? :friendly_id
     class << model_class
-      alias relation_without_friendly_id relation
+      alias_method :relation_without_friendly_id, :relation
     end
     model_class.class_eval do
       extend Base
@@ -102,8 +98,8 @@ module FriendlyId
   #     config.use :slugged
   #   end
   def self.defaults(&block)
-    @defaults = block if block_given?
-    @defaults ||= ->(config) {config.use :reserved}
+    @defaults = block if block
+    @defaults ||= ->(config) { config.use :reserved }
   end
 
   # Set the ActiveRecord table name prefix to friendly_id_

--- a/lib/friendly_id/base.rb
+++ b/lib/friendly_id/base.rb
@@ -1,62 +1,59 @@
 module FriendlyId
-=begin
-
-## Setting Up FriendlyId in Your Model
-
-To use FriendlyId in your ActiveRecord models, you must first either extend or
-include the FriendlyId module (it makes no difference), then invoke the
-{FriendlyId::Base#friendly_id friendly_id} method to configure your desired
-options:
-
-    class Foo < ActiveRecord::Base
-      include FriendlyId
-      friendly_id :bar, :use => [:slugged, :simple_i18n]
-    end
-
-The most important option is `:use`, which you use to tell FriendlyId which
-addons it should use. See the documentation for {FriendlyId::Base#friendly_id} for a list of all
-available addons, or skim through the rest of the docs to get a high-level
-overview.
-
-*A note about single table inheritance (STI): you must extend FriendlyId in
-all classes that participate in STI, both your parent classes and their
-children.*
-
-### The Default Setup: Simple Models
-
-The simplest way to use FriendlyId is with a model that has a uniquely indexed
-column with no spaces or special characters, and that is seldom or never
-updated. The most common example of this is a user name:
-
-    class User < ActiveRecord::Base
-      extend FriendlyId
-      friendly_id :login
-      validates_format_of :login, :with => /\A[a-z0-9]+\z/i
-    end
-
-    @user = User.friendly.find "joe"   # the old User.find(1) still works, too
-    @user.to_param                     # returns "joe"
-    redirect_to @user                  # the URL will be /users/joe
-
-In this case, FriendlyId assumes you want to use the column as-is; it will never
-modify the value of the column, and your application should ensure that the
-value is unique and admissible in a URL:
-
-    class City < ActiveRecord::Base
-      extend FriendlyId
-      friendly_id :name
-    end
-
-    @city.friendly.find "Viña del Mar"
-    redirect_to @city # the URL will be /cities/Viña%20del%20Mar
-
-Writing the code to process an arbitrary string into a good identifier for use
-in a URL can be repetitive and surprisingly tricky, so for this reason it's
-often better and easier to use {FriendlyId::Slugged slugs}.
-
-=end
+  #
+  ## Setting Up FriendlyId in Your Model
+  #
+  # To use FriendlyId in your ActiveRecord models, you must first either extend or
+  # include the FriendlyId module (it makes no difference), then invoke the
+  # {FriendlyId::Base#friendly_id friendly_id} method to configure your desired
+  # options:
+  #
+  #     class Foo < ActiveRecord::Base
+  #       include FriendlyId
+  #       friendly_id :bar, :use => [:slugged, :simple_i18n]
+  #     end
+  #
+  # The most important option is `:use`, which you use to tell FriendlyId which
+  # addons it should use. See the documentation for {FriendlyId::Base#friendly_id} for a list of all
+  # available addons, or skim through the rest of the docs to get a high-level
+  # overview.
+  #
+  # *A note about single table inheritance (STI): you must extend FriendlyId in
+  # all classes that participate in STI, both your parent classes and their
+  # children.*
+  #
+  ### The Default Setup: Simple Models
+  #
+  # The simplest way to use FriendlyId is with a model that has a uniquely indexed
+  # column with no spaces or special characters, and that is seldom or never
+  # updated. The most common example of this is a user name:
+  #
+  #     class User < ActiveRecord::Base
+  #       extend FriendlyId
+  #       friendly_id :login
+  #       validates_format_of :login, :with => /\A[a-z0-9]+\z/i
+  #     end
+  #
+  #     @user = User.friendly.find "joe"   # the old User.find(1) still works, too
+  #     @user.to_param                     # returns "joe"
+  #     redirect_to @user                  # the URL will be /users/joe
+  #
+  # In this case, FriendlyId assumes you want to use the column as-is; it will never
+  # modify the value of the column, and your application should ensure that the
+  # value is unique and admissible in a URL:
+  #
+  #     class City < ActiveRecord::Base
+  #       extend FriendlyId
+  #       friendly_id :name
+  #     end
+  #
+  #     @city.friendly.find "Viña del Mar"
+  #     redirect_to @city # the URL will be /cities/Viña%20del%20Mar
+  #
+  # Writing the code to process an arbitrary string into a good identifier for use
+  # in a URL can be repetitive and surprisingly tricky, so for this reason it's
+  # often better and easier to use {FriendlyId::Slugged slugs}.
+  #
   module Base
-
     # Configure FriendlyId's behavior in a model.
     #
     #     class Post < ActiveRecord::Base
@@ -205,10 +202,10 @@ often better and easier to use {FriendlyId::Slugged slugs}.
     #
     # @yieldparam config The model class's {FriendlyId::Configuration friendly_id_config}.
     def friendly_id(base = nil, options = {}, &block)
-      yield friendly_id_config if block_given?
+      yield friendly_id_config if block
       friendly_id_config.dependent = options.delete :dependent
       friendly_id_config.use options.delete :use
-      friendly_id_config.send :set, base ? options.merge(:base => base) : options
+      friendly_id_config.send :set, base ? options.merge(base: base) : options
       include Model
     end
 
@@ -270,7 +267,7 @@ often better and easier to use {FriendlyId::Slugged slugs}.
 
     # Clears slug on duplicate records when calling `dup`.
     def dup
-      super.tap { |duplicate| duplicate.slug = nil if duplicate.respond_to?('slug=') }
+      super.tap { |duplicate| duplicate.slug = nil if duplicate.respond_to?("slug=") }
     end
   end
 end

--- a/lib/friendly_id/candidates.rb
+++ b/lib/friendly_id/candidates.rb
@@ -1,11 +1,9 @@
-require 'securerandom'
+require "securerandom"
 
 module FriendlyId
-
   # This class provides the slug candidate functionality.
   # @see FriendlyId::Slugged
   class Candidates
-
     include Enumerable
 
     def initialize(object, *array)
@@ -14,8 +12,8 @@ module FriendlyId
     end
 
     def each(*args, &block)
-      return candidates unless block_given?
-      candidates.each{ |candidate| yield candidate }
+      return candidates unless block
+      candidates.each { |candidate| yield candidate }
     end
 
     private
@@ -29,13 +27,13 @@ module FriendlyId
 
     def normalize(candidates)
       candidates.map do |candidate|
-        @object.normalize_friendly_id(candidate.map(&:call).join(' '))
-      end.select {|x| wanted?(x)}
+        @object.normalize_friendly_id(candidate.map(&:call).join(" "))
+      end.select { |x| wanted?(x) }
     end
 
     def filter(candidates)
-      unless candidates.all? {|x| reserved?(x)}
-        candidates.reject! {|x| reserved?(x)}
+      unless candidates.all? { |x| reserved?(x) }
+        candidates.reject! { |x| reserved?(x) }
       end
       candidates
     end
@@ -44,7 +42,7 @@ module FriendlyId
       array.map do |candidate|
         case candidate
         when String
-          [->{candidate}]
+          [-> { candidate }]
         when Array
           to_candidate_array(object, candidate).flatten
         when Symbol
@@ -53,7 +51,7 @@ module FriendlyId
           if candidate.respond_to?(:call)
             [candidate]
           else
-            [->{candidate.to_s}]
+            [-> { candidate.to_s }]
           end
         end
       end

--- a/lib/friendly_id/configuration.rb
+++ b/lib/friendly_id/configuration.rb
@@ -2,7 +2,6 @@ module FriendlyId
   # The configuration parameters passed to {Base#friendly_id} will be stored in
   # this object.
   class Configuration
-
     attr_writer :base
 
     # The default configuration options.
@@ -25,10 +24,10 @@ module FriendlyId
     attr_accessor :routes
 
     def initialize(model_class, values = nil)
-      @base           = nil
-      @model_class    = model_class
-      @defaults       = {}
-      @modules        = []
+      @base = nil
+      @model_class = model_class
+      @defaults = {}
+      @modules = []
       @finder_methods = FriendlyId::FinderMethods
       self.routes = :friendly
       set values
@@ -102,11 +101,11 @@ module FriendlyId
     private
 
     def get_module(object)
-      Module === object ? object : FriendlyId.const_get(object.to_s.titleize.camelize.gsub(/\s+/, ''))
+      Module === object ? object : FriendlyId.const_get(object.to_s.titleize.camelize.gsub(/\s+/, ""))
     end
 
     def set(values)
-      values and values.each {|name, value| self.send "#{name}=", value}
+      values&.each { |name, value| send "#{name}=", value }
     end
   end
 end

--- a/lib/friendly_id/finder_methods.rb
+++ b/lib/friendly_id/finder_methods.rb
@@ -1,7 +1,5 @@
 module FriendlyId
-
   module FinderMethods
-
     # Finds a record using the given id.
     #
     # If the id is "unfriendly", it will call the original find method.
@@ -18,7 +16,7 @@ module FriendlyId
     def find(*args)
       id = args.first
       return super if args.count != 1 || id.unfriendly_id?
-      first_by_friendly_id(id).tap {|result| return result unless result.nil?}
+      first_by_friendly_id(id).tap { |result| return result unless result.nil? }
       return super if potential_primary_key?(id)
 
       raise_not_found_exception(id)
@@ -50,7 +48,11 @@ module FriendlyId
       key_type = key_type.type if key_type.respond_to?(:type)
       case key_type
       when :integer
-        Integer(id, 10) rescue false
+        begin
+          Integer(id, 10)
+        rescue
+          false
+        end
       when :uuid
         id.match(/\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/)
       else
@@ -97,12 +99,11 @@ module FriendlyId
 
     def raise_not_found_exception(id)
       message = "can't find record with friendly id: #{id.inspect}"
-      if ActiveRecord.version < Gem::Version.create('5.0')
+      if ActiveRecord.version < Gem::Version.create("5.0")
         raise ActiveRecord::RecordNotFound.new(message)
       else
         raise ActiveRecord::RecordNotFound.new(message, name, friendly_id_config.query_field, id)
       end
     end
-
   end
 end

--- a/lib/friendly_id/finders.rb
+++ b/lib/friendly_id/finders.rb
@@ -1,73 +1,70 @@
 module FriendlyId
-=begin
-## Performing Finds with FriendlyId
-
-FriendlyId offers enhanced finders which will search for your record by
-friendly id, and fall back to the numeric id if necessary. This makes it easy
-to add FriendlyId to an existing application with minimal code modification.
-
-By default, these methods are available only on the `friendly` scope:
-
-    Restaurant.friendly.find('plaza-diner') #=> works
-    Restaurant.friendly.find(23)            #=> also works
-    Restaurant.find(23)                     #=> still works
-    Restaurant.find('plaza-diner')          #=> will not work
-
-### Restoring FriendlyId 4.0-style finders
-
-Prior to version 5.0, FriendlyId overrode the default finder methods to perform
-friendly finds all the time. This required modifying parts of Rails that did
-not have a public API, which was harder to maintain and at times caused
-compatiblity problems. In 5.0 we decided to change the library's defaults and add
-the friendly finder methods only to the `friendly` scope in order to boost
-compatiblity. However, you can still opt-in to original functionality very
-easily by using the `:finders` addon:
-
-    class Restaurant < ActiveRecord::Base
-      extend FriendlyId
-
-      scope :active, -> {where(:active => true)}
-
-      friendly_id :name, :use => [:slugged, :finders]
-    end
-
-    Restaurant.friendly.find('plaza-diner') #=> works
-    Restaurant.find('plaza-diner')          #=> now also works
-    Restaurant.active.find('plaza-diner')   #=> now also works
-
-### Updating your application to use FriendlyId's finders
-
-Unless you've chosen to use the `:finders` addon, be sure to modify the finders
-in your controllers to use the `friendly` scope. For example:
-
-    # before
-    def set_restaurant
-      @restaurant = Restaurant.find(params[:id])
-    end
-
-    # after
-    def set_restaurant
-      @restaurant = Restaurant.friendly.find(params[:id])
-    end
-
-#### Active Admin
-
-Unless you use the `:finders` addon, you should modify your admin controllers
-for models that use FriendlyId with something similar to the following:
-
-    controller do
-      def find_resource
-        scoped_collection.friendly.find(params[:id])
-      end
-    end
-
-=end
+  # ## Performing Finds with FriendlyId
+  #
+  # FriendlyId offers enhanced finders which will search for your record by
+  # friendly id, and fall back to the numeric id if necessary. This makes it easy
+  # to add FriendlyId to an existing application with minimal code modification.
+  #
+  # By default, these methods are available only on the `friendly` scope:
+  #
+  #     Restaurant.friendly.find('plaza-diner') #=> works
+  #     Restaurant.friendly.find(23)            #=> also works
+  #     Restaurant.find(23)                     #=> still works
+  #     Restaurant.find('plaza-diner')          #=> will not work
+  #
+  ### Restoring FriendlyId 4.0-style finders
+  #
+  # Prior to version 5.0, FriendlyId overrode the default finder methods to perform
+  # friendly finds all the time. This required modifying parts of Rails that did
+  # not have a public API, which was harder to maintain and at times caused
+  # compatiblity problems. In 5.0 we decided to change the library's defaults and add
+  # the friendly finder methods only to the `friendly` scope in order to boost
+  # compatiblity. However, you can still opt-in to original functionality very
+  # easily by using the `:finders` addon:
+  #
+  #     class Restaurant < ActiveRecord::Base
+  #       extend FriendlyId
+  #
+  #       scope :active, -> {where(:active => true)}
+  #
+  #       friendly_id :name, :use => [:slugged, :finders]
+  #     end
+  #
+  #     Restaurant.friendly.find('plaza-diner') #=> works
+  #     Restaurant.find('plaza-diner')          #=> now also works
+  #     Restaurant.active.find('plaza-diner')   #=> now also works
+  #
+  ### Updating your application to use FriendlyId's finders
+  #
+  # Unless you've chosen to use the `:finders` addon, be sure to modify the finders
+  # in your controllers to use the `friendly` scope. For example:
+  #
+  #     # before
+  #     def set_restaurant
+  #       @restaurant = Restaurant.find(params[:id])
+  #     end
+  #
+  #     # after
+  #     def set_restaurant
+  #       @restaurant = Restaurant.friendly.find(params[:id])
+  #     end
+  #
+  #### Active Admin
+  #
+  # Unless you use the `:finders` addon, you should modify your admin controllers
+  # for models that use FriendlyId with something similar to the following:
+  #
+  #     controller do
+  #       def find_resource
+  #         scoped_collection.friendly.find(params[:id])
+  #       end
+  #     end
+  #
   module Finders
-
     module ClassMethods
       if (ActiveRecord::VERSION::MAJOR == 4) && (ActiveRecord::VERSION::MINOR == 0)
         def relation_delegate_class(klass)
-          relation_class_name = :"#{klass.to_s.gsub('::', '_')}_#{self.to_s.gsub('::', '_')}"
+          relation_class_name = :"#{klass.to_s.gsub("::", "_")}_#{to_s.gsub("::", "_")}"
           klass.const_get(relation_class_name)
         end
       end
@@ -82,7 +79,7 @@ for models that use FriendlyId with something similar to the following:
       end
 
       # Support for friendly finds on associations for Rails 4.0.1 and above.
-      if ::ActiveRecord.const_defined?('AssociationRelation')
+      if ::ActiveRecord.const_defined?("AssociationRelation")
         model_class.extend(ClassMethods)
         association_relation_delegate_class = model_class.relation_delegate_class(::ActiveRecord::AssociationRelation)
         association_relation_delegate_class.send(:include, model_class.friendly_id_config.finder_methods)

--- a/lib/friendly_id/history.rb
+++ b/lib/friendly_id/history.rb
@@ -1,59 +1,55 @@
 module FriendlyId
-
-=begin
-
-## History: Avoiding 404's When Slugs Change
-
-FriendlyId's {FriendlyId::History History} module adds the ability to store a
-log of a model's slugs, so that when its friendly id changes, it's still
-possible to perform finds by the old id.
-
-The primary use case for this is avoiding broken URLs.
-
-### Setup
-
-In order to use this module, you must add a table to your database schema to
-store the slug records. FriendlyId provides a generator for this purpose:
-
-    rails generate friendly_id
-    rake db:migrate
-
-This will add a table named `friendly_id_slugs`, used by the {FriendlyId::Slug}
-model.
-
-### Considerations
-
-Because recording slug history requires creating additional database records,
-this module has an impact on the performance of the associated model's `create`
-method.
-
-### Example
-
-    class Post < ActiveRecord::Base
-      extend FriendlyId
-      friendly_id :title, :use => :history
-    end
-
-    class PostsController < ApplicationController
-
-      before_filter :find_post
-
-      ...
-
-      def find_post
-        @post = Post.friendly.find params[:id]
-
-        # If an old id or a numeric id was used to find the record, then
-        # the request slug will not match the current slug, and we should do
-        # a 301 redirect to the new path
-        if params[:id] != @post.slug
-          return redirect_to @post, :status => :moved_permanently
-        end
-      end
-    end
-=end
+  #
+  ## History: Avoiding 404's When Slugs Change
+  #
+  # FriendlyId's {FriendlyId::History History} module adds the ability to store a
+  # log of a model's slugs, so that when its friendly id changes, it's still
+  # possible to perform finds by the old id.
+  #
+  # The primary use case for this is avoiding broken URLs.
+  #
+  ### Setup
+  #
+  # In order to use this module, you must add a table to your database schema to
+  # store the slug records. FriendlyId provides a generator for this purpose:
+  #
+  #     rails generate friendly_id
+  #     rake db:migrate
+  #
+  # This will add a table named `friendly_id_slugs`, used by the {FriendlyId::Slug}
+  # model.
+  #
+  ### Considerations
+  #
+  # Because recording slug history requires creating additional database records,
+  # this module has an impact on the performance of the associated model's `create`
+  # method.
+  #
+  ### Example
+  #
+  #     class Post < ActiveRecord::Base
+  #       extend FriendlyId
+  #       friendly_id :title, :use => :history
+  #     end
+  #
+  #     class PostsController < ApplicationController
+  #
+  #       before_filter :find_post
+  #
+  #       ...
+  #
+  #       def find_post
+  #         @post = Post.friendly.find params[:id]
+  #
+  #         # If an old id or a numeric id was used to find the record, then
+  #         # the request slug will not match the current slug, and we should do
+  #         # a 301 redirect to the new path
+  #         if params[:id] != @post.slug
+  #           return redirect_to @post, :status => :moved_permanently
+  #         end
+  #       end
+  #     end
   module History
-
     module Configuration
       def dependent_value
         dependent.nil? ? :destroy : dependent
@@ -72,10 +68,10 @@ method.
     # Configures the model instance to use the History add-on.
     def self.included(model_class)
       model_class.class_eval do
-        has_many :slugs, -> {order(id: :desc)}, **{
-          :as         => :sluggable,
-          :dependent  => @friendly_id_config.dependent_value,
-          :class_name => Slug.to_s
+        has_many :slugs, -> { order(id: :desc) }, **{
+          as: :sluggable,
+          dependent: @friendly_id_config.dependent_value,
+          class_name: Slug.to_s
         }
 
         after_save :create_slug
@@ -96,7 +92,7 @@ method.
       end
 
       def slug_table_record(id)
-        select(quoted_table_name + '.*').joins(:slugs).where(slug_history_clause(id)).order(Slug.arel_table[:id].desc).first
+        select(quoted_table_name + ".*").joins(:slugs).where(slug_history_clause(id)).order(Slug.arel_table[:id].desc).first
       end
 
       def slug_history_clause(id)
@@ -112,7 +108,7 @@ method.
     def scope_for_slug_generator
       relation = super.joins(:slugs)
       unless new_record?
-        relation = relation.merge(Slug.where('sluggable_id <> ?', id))
+        relation = relation.merge(Slug.where("sluggable_id <> ?", id))
       end
       if friendly_id_config.uses?(:scoped)
         relation = relation.where(Slug.arel_table[:scope].eq(serialized_scope))
@@ -124,9 +120,9 @@ method.
       return unless friendly_id
       return if history_is_up_to_date?
       # Allow reversion back to a previously used slug
-      relation = slugs.where(:slug => friendly_id)
+      relation = slugs.where(slug: friendly_id)
       if friendly_id_config.uses?(:scoped)
-        relation = relation.where(:scope => serialized_scope)
+        relation = relation.where(scope: serialized_scope)
       end
       relation.destroy_all unless relation.empty?
       slugs.create! do |record|
@@ -139,7 +135,7 @@ method.
       latest_history = slugs.first
       check = latest_history.try(:slug) == friendly_id
       if friendly_id_config.uses?(:scoped)
-        check = check && latest_history.scope == serialized_scope
+        check &&= latest_history.scope == serialized_scope
       end
       check
     end

--- a/lib/friendly_id/initializer.rb
+++ b/lib/friendly_id/initializer.rb
@@ -16,9 +16,9 @@ FriendlyId.defaults do |config|
   # undesirable to allow as slugs. Edit this list as needed for your app.
   config.use :reserved
 
-  config.reserved_words = %w(new edit index session login logout users admin
-    stylesheets assets javascripts images)
-    
+  config.reserved_words = %w[new edit index session login logout users admin
+    stylesheets assets javascripts images]
+
   # This adds an option to treat reserved words as conflicts rather than exceptions.
   # When there is no good candidate, a UUID will be appended, matching the existing
   # conflict behavior.

--- a/lib/friendly_id/migration.rb
+++ b/lib/friendly_id/migration.rb
@@ -8,14 +8,14 @@ MIGRATION_CLASS =
 class CreateFriendlyIdSlugs < MIGRATION_CLASS
   def change
     create_table :friendly_id_slugs do |t|
-      t.string   :slug,           :null => false
-      t.integer  :sluggable_id,   :null => false
-      t.string   :sluggable_type, :limit => 50
-      t.string   :scope
+      t.string :slug, null: false
+      t.integer :sluggable_id, null: false
+      t.string :sluggable_type, limit: 50
+      t.string :scope
       t.datetime :created_at
     end
     add_index :friendly_id_slugs, [:sluggable_type, :sluggable_id]
-    add_index :friendly_id_slugs, [:slug, :sluggable_type], length: { slug: 140, sluggable_type: 50 }
-    add_index :friendly_id_slugs, [:slug, :sluggable_type, :scope], length: { slug: 70, sluggable_type: 50, scope: 70 }, unique: true
+    add_index :friendly_id_slugs, [:slug, :sluggable_type], length: {slug: 140, sluggable_type: 50}
+    add_index :friendly_id_slugs, [:slug, :sluggable_type, :scope], length: {slug: 70, sluggable_type: 50, scope: 70}, unique: true
   end
 end

--- a/lib/friendly_id/object_utils.rb
+++ b/lib/friendly_id/object_utils.rb
@@ -19,7 +19,6 @@ module FriendlyId
   # names that unambigously refer to the library of their origin, which should
   # be sufficient to avoid conflicts with other libraries.
   module ObjectUtils
-
     # True if the id is definitely friendly, false if definitely unfriendly,
     # else nil.
     #
@@ -45,7 +44,8 @@ module FriendlyId
     # True if the id is definitely unfriendly, false if definitely friendly,
     # else nil.
     def unfriendly_id?
-      val = friendly_id? ; !val unless val.nil?
+      val = friendly_id?
+      !val unless val.nil?
     end
   end
 

--- a/lib/friendly_id/reserved.rb
+++ b/lib/friendly_id/reserved.rb
@@ -1,42 +1,38 @@
 module FriendlyId
-
-=begin
-
-## Reserved Words
-
-The {FriendlyId::Reserved Reserved} module adds the ability to exclude a list of
-words from use as FriendlyId slugs.
-
-With Ruby on Rails, FriendlyId's generator generates an initializer that
-reserves some words such as "new" and "edit" using {FriendlyId.defaults
-FriendlyId.defaults}.
-
-Note that the error messages for fields will appear on the field
-`:friendly_id`. If you are using Rails's scaffolded form errors display, then
-it will have no field to highlight. If you'd like to change this so that
-scaffolding works as expected, one way to accomplish this is to move the error
-message to a different field. For example:
-
-    class Person < ActiveRecord::Base
-      extend FriendlyId
-      friendly_id :name, use: :slugged
-
-      after_validation :move_friendly_id_error_to_name
-
-      def move_friendly_id_error_to_name
-        errors.add :name, *errors.delete(:friendly_id) if errors[:friendly_id].present?
-      end
-    end
-
-=end
+  #
+  ## Reserved Words
+  #
+  # The {FriendlyId::Reserved Reserved} module adds the ability to exclude a list of
+  # words from use as FriendlyId slugs.
+  #
+  # With Ruby on Rails, FriendlyId's generator generates an initializer that
+  # reserves some words such as "new" and "edit" using {FriendlyId.defaults
+  # FriendlyId.defaults}.
+  #
+  # Note that the error messages for fields will appear on the field
+  # `:friendly_id`. If you are using Rails's scaffolded form errors display, then
+  # it will have no field to highlight. If you'd like to change this so that
+  # scaffolding works as expected, one way to accomplish this is to move the error
+  # message to a different field. For example:
+  #
+  #     class Person < ActiveRecord::Base
+  #       extend FriendlyId
+  #       friendly_id :name, use: :slugged
+  #
+  #       after_validation :move_friendly_id_error_to_name
+  #
+  #       def move_friendly_id_error_to_name
+  #         errors.add :name, *errors.delete(:friendly_id) if errors[:friendly_id].present?
+  #       end
+  #     end
+  #
   module Reserved
-
     # When included, this module adds configuration options to the model class's
     # friendly_id_config.
     def self.included(model_class)
       model_class.class_eval do
         friendly_id_config.class.send :include, Reserved::Configuration
-        validates_exclusion_of :friendly_id, :in => ->(_) {
+        validates_exclusion_of :friendly_id, in: ->(_) {
           friendly_id_config.reserved_words || []
         }
       end

--- a/lib/friendly_id/scoped.rb
+++ b/lib/friendly_id/scoped.rb
@@ -1,108 +1,104 @@
 require "friendly_id/slugged"
 
 module FriendlyId
-
-=begin
-
-## Unique Slugs by Scope
-
-The {FriendlyId::Scoped} module allows FriendlyId to generate unique slugs
-within a scope.
-
-This allows, for example, two restaurants in different cities to have the slug
-`joes-diner`:
-
-    class Restaurant < ActiveRecord::Base
-      extend FriendlyId
-      belongs_to :city
-      friendly_id :name, :use => :scoped, :scope => :city
-    end
-
-    class City < ActiveRecord::Base
-      extend FriendlyId
-      has_many :restaurants
-      friendly_id :name, :use => :slugged
-    end
-
-    City.friendly.find("seattle").restaurants.friendly.find("joes-diner")
-    City.friendly.find("chicago").restaurants.friendly.find("joes-diner")
-
-Without :scoped in this case, one of the restaurants would have the slug
-`joes-diner` and the other would have `joes-diner-f9f3789a-daec-4156-af1d-fab81aa16ee5`.
-
-The value for the `:scope` option can be the name of a `belongs_to` relation, or
-a column.
-
-Additionally, the `:scope` option can receive an array of scope values:
-
-    class Cuisine < ActiveRecord::Base
-      extend FriendlyId
-      has_many :restaurants
-      friendly_id :name, :use => :slugged
-    end
-
-    class City < ActiveRecord::Base
-      extend FriendlyId
-      has_many :restaurants
-      friendly_id :name, :use => :slugged
-    end
-
-    class Restaurant < ActiveRecord::Base
-      extend FriendlyId
-      belongs_to :city
-      friendly_id :name, :use => :scoped, :scope => [:city, :cuisine]
-    end
-
-All supplied values will be used to determine scope.
-
-### Finding Records by Friendly ID
-
-If you are using scopes your friendly ids may not be unique, so a simple find
-like:
-
-    Restaurant.friendly.find("joes-diner")
-
-may return the wrong record. In these cases it's best to query through the
-relation:
-
-    @city.restaurants.friendly.find("joes-diner")
-
-Alternatively, you could pass the scope value as a query parameter:
-
-    Restaurant.where(:city_id => @city.id).friendly.find("joes-diner")
-
-
-### Finding All Records That Match a Scoped ID
-
-Query the slug column directly:
-
-    Restaurant.where(:slug => "joes-diner")
-
-### Routes for Scoped Models
-
-Recall that FriendlyId is a database-centric library, and does not set up any
-routes for scoped models. You must do this yourself in your application. Here's
-an example of one way to set this up:
-
-    # in routes.rb
-    resources :cities do
-      resources :restaurants
-    end
-
-    # in views
-    <%= link_to 'Show', [@city, @restaurant] %>
-
-    # in controllers
-    @city = City.friendly.find(params[:city_id])
-    @restaurant = @city.restaurants.friendly.find(params[:id])
-
-    # URLs:
-    http://example.org/cities/seattle/restaurants/joes-diner
-    http://example.org/cities/chicago/restaurants/joes-diner
-
-=end
+  #
+  ## Unique Slugs by Scope
+  #
+  # The {FriendlyId::Scoped} module allows FriendlyId to generate unique slugs
+  # within a scope.
+  #
+  # This allows, for example, two restaurants in different cities to have the slug
+  # `joes-diner`:
+  #
+  #     class Restaurant < ActiveRecord::Base
+  #       extend FriendlyId
+  #       belongs_to :city
+  #       friendly_id :name, :use => :scoped, :scope => :city
+  #     end
+  #
+  #     class City < ActiveRecord::Base
+  #       extend FriendlyId
+  #       has_many :restaurants
+  #       friendly_id :name, :use => :slugged
+  #     end
+  #
+  #     City.friendly.find("seattle").restaurants.friendly.find("joes-diner")
+  #     City.friendly.find("chicago").restaurants.friendly.find("joes-diner")
+  #
+  # Without :scoped in this case, one of the restaurants would have the slug
+  # `joes-diner` and the other would have `joes-diner-f9f3789a-daec-4156-af1d-fab81aa16ee5`.
+  #
+  # The value for the `:scope` option can be the name of a `belongs_to` relation, or
+  # a column.
+  #
+  # Additionally, the `:scope` option can receive an array of scope values:
+  #
+  #     class Cuisine < ActiveRecord::Base
+  #       extend FriendlyId
+  #       has_many :restaurants
+  #       friendly_id :name, :use => :slugged
+  #     end
+  #
+  #     class City < ActiveRecord::Base
+  #       extend FriendlyId
+  #       has_many :restaurants
+  #       friendly_id :name, :use => :slugged
+  #     end
+  #
+  #     class Restaurant < ActiveRecord::Base
+  #       extend FriendlyId
+  #       belongs_to :city
+  #       friendly_id :name, :use => :scoped, :scope => [:city, :cuisine]
+  #     end
+  #
+  # All supplied values will be used to determine scope.
+  #
+  ### Finding Records by Friendly ID
+  #
+  # If you are using scopes your friendly ids may not be unique, so a simple find
+  # like:
+  #
+  #     Restaurant.friendly.find("joes-diner")
+  #
+  # may return the wrong record. In these cases it's best to query through the
+  # relation:
+  #
+  #     @city.restaurants.friendly.find("joes-diner")
+  #
+  # Alternatively, you could pass the scope value as a query parameter:
+  #
+  #     Restaurant.where(:city_id => @city.id).friendly.find("joes-diner")
+  #
+  #
+  ### Finding All Records That Match a Scoped ID
+  #
+  # Query the slug column directly:
+  #
+  #     Restaurant.where(:slug => "joes-diner")
+  #
+  ### Routes for Scoped Models
+  #
+  # Recall that FriendlyId is a database-centric library, and does not set up any
+  # routes for scoped models. You must do this yourself in your application. Here's
+  # an example of one way to set this up:
+  #
+  #     # in routes.rb
+  #     resources :cities do
+  #       resources :restaurants
+  #     end
+  #
+  #     # in views
+  #     <%= link_to 'Show', [@city, @restaurant] %>
+  #
+  #     # in controllers
+  #     @city = City.friendly.find(params[:city_id])
+  #     @restaurant = @city.restaurants.friendly.find(params[:id])
+  #
+  #     # URLs:
+  #     http://example.org/cities/seattle/restaurants/joes-diner
+  #     http://example.org/cities/chicago/restaurants/joes-diner
+  #
   module Scoped
-
     # FriendlyId::Config.use will invoke this method when present, to allow
     # loading dependent modules prior to overriding them when necessary.
     def self.setup(model_class)
@@ -146,7 +142,6 @@ an example of one way to set this up:
     # This module adds the `:scope` configuration option to
     # {FriendlyId::Configuration FriendlyId::Configuration}.
     module Configuration
-
       # Gets the scope value.
       #
       # When setting this value, the argument should be a symbol referencing a

--- a/lib/friendly_id/sequentially_slugged.rb
+++ b/lib/friendly_id/sequentially_slugged.rb
@@ -1,4 +1,4 @@
-require_relative 'sequentially_slugged/calculator'
+require_relative "sequentially_slugged/calculator"
 
 module FriendlyId
   module SequentiallySlugged

--- a/lib/friendly_id/sequentially_slugged/calculator.rb
+++ b/lib/friendly_id/sequentially_slugged/calculator.rb
@@ -21,7 +21,7 @@ module FriendlyId
         base = "#{slug_column} = ? OR #{slug_column} LIKE ?"
         # Awful hack for SQLite3, which does not pick up '\' as the escape character
         # without this.
-        base << " ESCAPE '\\'" if scope.connection.adapter_name =~ /sqlite/i
+        base << " ESCAPE '\\'" if /sqlite/i.match?(scope.connection.adapter_name)
         base
       end
 
@@ -52,17 +52,17 @@ module FriendlyId
         # Underscores (matching a single character) and percent signs (matching
         # any number of characters) need to be escaped. While this looks like
         # an excessive number of backslashes, it is correct.
-        "#{slug}#{sequence_separator}".gsub(/[_%]/, '\\\\\&') + '%'
+        "#{slug}#{sequence_separator}".gsub(/[_%]/, '\\\\\&') + "%"
       end
 
       def slug_conflicts
-        scope.
-          where(conflict_query, slug, sequential_slug_matcher).
-          order(Arel.sql(ordering_query)).pluck(Arel.sql(slug_column))
+        scope
+          .where(conflict_query, slug, sequential_slug_matcher)
+          .order(Arel.sql(ordering_query)).pluck(Arel.sql(slug_column))
       end
 
       def sql_length
-        scope.connection.adapter_name =~ /sqlserver/i ? 'LEN' : 'LENGTH'
+        /sqlserver/i.match?(scope.connection.adapter_name) ? "LEN" : "LENGTH"
       end
     end
   end

--- a/lib/friendly_id/simple_i18n.rb
+++ b/lib/friendly_id/simple_i18n.rb
@@ -1,79 +1,75 @@
 require "i18n"
 
 module FriendlyId
-
-=begin
-
-## Translating Slugs Using Simple I18n
-
-The {FriendlyId::SimpleI18n SimpleI18n} module adds very basic i18n support to
-FriendlyId.
-
-In order to use this module, your model must have a slug column for each locale.
-By default FriendlyId looks for columns named, for example, "slug_en",
-"slug_es", "slug_pt_br", etc. The first part of the name can be configured by
-passing the `:slug_column` option if you choose. Note that the column for the
-default locale must also include the locale in its name.
-
-This module is most suitable to applications that need to support few locales.
-If you need to support two or more locales, you may wish to use the
-friendly_id_globalize gem instead.
-
-### Example migration
-
-    def self.up
-      create_table :posts do |t|
-        t.string :title
-        t.string :slug_en
-        t.string :slug_es
-        t.string :slug_pt_br
-        t.text   :body
-      end
-      add_index :posts, :slug_en
-      add_index :posts, :slug_es
-      add_index :posts, :slug_pt_br
-    end
-
-### Finds
-
-Finds will take into consideration the current locale:
-
-    I18n.locale = :es
-    Post.friendly.find("la-guerra-de-las-galaxias")
-    I18n.locale = :en
-    Post.friendly.find("star-wars")
-    I18n.locale = :"pt-BR"
-    Post.friendly.find("guerra-das-estrelas")
-
-To find a slug by an explicit locale, perform the find inside a block
-passed to I18n's `with_locale` method:
-
-    I18n.with_locale(:es) do
-      Post.friendly.find("la-guerra-de-las-galaxias")
-    end
-
-### Creating Records
-
-When new records are created, the slug is generated for the current locale only.
-
-### Translating Slugs
-
-To translate an existing record's friendly_id, use
-{FriendlyId::SimpleI18n::Model#set_friendly_id}. This will ensure that the slug
-you add is properly escaped, transliterated and sequenced:
-
-    post = Post.create :name => "Star Wars"
-    post.set_friendly_id("La guerra de las galaxias", :es)
-
-If you don't pass in a locale argument, FriendlyId::SimpleI18n will just use the
-current locale:
-
-    I18n.with_locale(:es) do
-      post.set_friendly_id("La guerra de las galaxias")
-    end
-=end
+  #
+  ## Translating Slugs Using Simple I18n
+  #
+  # The {FriendlyId::SimpleI18n SimpleI18n} module adds very basic i18n support to
+  # FriendlyId.
+  #
+  # In order to use this module, your model must have a slug column for each locale.
+  # By default FriendlyId looks for columns named, for example, "slug_en",
+  # "slug_es", "slug_pt_br", etc. The first part of the name can be configured by
+  # passing the `:slug_column` option if you choose. Note that the column for the
+  # default locale must also include the locale in its name.
+  #
+  # This module is most suitable to applications that need to support few locales.
+  # If you need to support two or more locales, you may wish to use the
+  # friendly_id_globalize gem instead.
+  #
+  ### Example migration
+  #
+  #     def self.up
+  #       create_table :posts do |t|
+  #         t.string :title
+  #         t.string :slug_en
+  #         t.string :slug_es
+  #         t.string :slug_pt_br
+  #         t.text   :body
+  #       end
+  #       add_index :posts, :slug_en
+  #       add_index :posts, :slug_es
+  #       add_index :posts, :slug_pt_br
+  #     end
+  #
+  ### Finds
+  #
+  # Finds will take into consideration the current locale:
+  #
+  #     I18n.locale = :es
+  #     Post.friendly.find("la-guerra-de-las-galaxias")
+  #     I18n.locale = :en
+  #     Post.friendly.find("star-wars")
+  #     I18n.locale = :"pt-BR"
+  #     Post.friendly.find("guerra-das-estrelas")
+  #
+  # To find a slug by an explicit locale, perform the find inside a block
+  # passed to I18n's `with_locale` method:
+  #
+  #     I18n.with_locale(:es) do
+  #       Post.friendly.find("la-guerra-de-las-galaxias")
+  #     end
+  #
+  ### Creating Records
+  #
+  # When new records are created, the slug is generated for the current locale only.
+  #
+  ### Translating Slugs
+  #
+  # To translate an existing record's friendly_id, use
+  # {FriendlyId::SimpleI18n::Model#set_friendly_id}. This will ensure that the slug
+  # you add is properly escaped, transliterated and sequenced:
+  #
+  #     post = Post.create :name => "Star Wars"
+  #     post.set_friendly_id("La guerra de las galaxias", :es)
+  #
+  # If you don't pass in a locale argument, FriendlyId::SimpleI18n will just use the
+  # current locale:
+  #
+  #     I18n.with_locale(:es) do
+  #       post.set_friendly_id("La guerra de las galaxias")
+  #     end
   module SimpleI18n
-
     # FriendlyId::Config.use will invoke this method when present, to allow
     # loading dependent modules prior to overriding them when necessary.
     def self.setup(model_class)

--- a/lib/friendly_id/slug.rb
+++ b/lib/friendly_id/slug.rb
@@ -3,7 +3,7 @@ module FriendlyId
   #
   # @see FriendlyId::History
   class Slug < ActiveRecord::Base
-    belongs_to :sluggable, :polymorphic => true
+    belongs_to :sluggable, polymorphic: true
 
     def sluggable
       sluggable_type.constantize.unscoped { super }
@@ -12,6 +12,5 @@ module FriendlyId
     def to_param
       slug
     end
-
   end
 end

--- a/lib/friendly_id/slug_generator.rb
+++ b/lib/friendly_id/slug_generator.rb
@@ -2,7 +2,6 @@ module FriendlyId
   # The default slug generator offers functionality to check slug candidates for
   # availability.
   class SlugGenerator
-
     def initialize(scope, config)
       @scope = scope
       @config = config
@@ -17,9 +16,8 @@ module FriendlyId
     end
 
     def generate(candidates)
-      candidates.each {|c| return c if available?(c)}
+      candidates.each { |c| return c if available?(c) }
       nil
     end
-
   end
 end

--- a/lib/friendly_id/version.rb
+++ b/lib/friendly_id/version.rb
@@ -1,3 +1,3 @@
 module FriendlyId
-  VERSION = '6.0.0'.freeze
+  VERSION = "6.0.0".freeze
 end

--- a/lib/generators/friendly_id_generator.rb
+++ b/lib/generators/friendly_id_generator.rb
@@ -1,4 +1,4 @@
-require 'rails/generators'
+require "rails/generators"
 require "rails/generators/active_record"
 
 # This generator adds a migration for the {FriendlyId::History
@@ -6,21 +6,21 @@ require "rails/generators/active_record"
 class FriendlyIdGenerator < ActiveRecord::Generators::Base
   # ActiveRecord::Generators::Base inherits from Rails::Generators::NamedBase which requires a NAME parameter for the
   # new table name. Our generator always uses 'friendly_id_slugs', so we just set a random name here.
-  argument :name, type: :string, default: 'random_name'
+  argument :name, type: :string, default: "random_name"
 
-  class_option :'skip-migration', :type => :boolean, :desc => "Don't generate a migration for the slugs table"
-  class_option :'skip-initializer', :type => :boolean, :desc => "Don't generate an initializer"
+  class_option :'skip-migration', type: :boolean, desc: "Don't generate a migration for the slugs table"
+  class_option :'skip-initializer', type: :boolean, desc: "Don't generate an initializer"
 
-  source_root File.expand_path('../../friendly_id', __FILE__)
+  source_root File.expand_path("../../friendly_id", __FILE__)
 
   # Copies the migration template to db/migrate.
   def copy_files
-    return if options['skip-migration']
-    migration_template 'migration.rb', 'db/migrate/create_friendly_id_slugs.rb'
+    return if options["skip-migration"]
+    migration_template "migration.rb", "db/migrate/create_friendly_id_slugs.rb"
   end
 
   def create_initializer
-    return if options['skip-initializer']
-    copy_file 'initializer.rb', 'config/initializers/friendly_id.rb'
+    return if options["skip-initializer"]
+    copy_file "initializer.rb", "config/initializers/friendly_id.rb"
   end
 end

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -21,13 +21,12 @@ class CoreTest < TestCaseClass
     klass = Class.new(ActiveRecord::Base) do
       self.abstract_class = true
       extend FriendlyId
-      friendly_id :foo, :use => :slugged, :slug_column => :bar
+      friendly_id :foo, use: :slugged, slug_column: :bar
     end
     assert klass < FriendlyId::Slugged
     assert_equal :foo, klass.friendly_id_config.base
     assert_equal :bar, klass.friendly_id_config.slug_column
   end
-
 
   test "friendly_id should accept a block" do
     klass = Class.new(ActiveRecord::Base) do
@@ -56,17 +55,15 @@ class CoreTest < TestCaseClass
   end
 
   test "should allow defaults to be set via a block" do
-    begin
-      FriendlyId.defaults do |config|
-        config.base = :foo
-      end
-      klass = Class.new(ActiveRecord::Base) do
-        self.abstract_class = true
-        extend FriendlyId
-      end
-      assert_equal :foo, klass.friendly_id_config.base
-    ensure
-      FriendlyId.instance_variable_set :@defaults, nil
+    FriendlyId.defaults do |config|
+      config.base = :foo
     end
+    klass = Class.new(ActiveRecord::Base) do
+      self.abstract_class = true
+      extend FriendlyId
+    end
+    assert_equal :foo, klass.friendly_id_config.base
+  ensure
+    FriendlyId.instance_variable_set :@defaults, nil
   end
 end

--- a/test/benchmarks/object_utils.rb
+++ b/test/benchmarks/object_utils.rb
@@ -28,7 +28,7 @@ Book = Class.new ActiveRecord::Base
 
 test_integer = 123
 test_active_record_object = Book.new
-test_hash = {:name=>'joe'}
+test_hash = {name: "joe"}
 test_nil = nil
 test_numeric_string = "123"
 test_string = "abc123"
@@ -36,21 +36,21 @@ test_string = "abc123"
 N = 5_000_000
 
 Benchmark.bmbm do |x|
-  x.report('integer friendly_id?') { N.times {test_integer.friendly_id?} }
-  x.report('integer unfriendly_id?') { N.times {test_integer.unfriendly_id?} }
+  x.report("integer friendly_id?") { N.times { test_integer.friendly_id? } }
+  x.report("integer unfriendly_id?") { N.times { test_integer.unfriendly_id? } }
 
-  x.report('AR::Base friendly_id?') { N.times {test_active_record_object.friendly_id?} }
-  x.report('AR::Base unfriendly_id?') { N.times {test_active_record_object.unfriendly_id?} }
+  x.report("AR::Base friendly_id?") { N.times { test_active_record_object.friendly_id? } }
+  x.report("AR::Base unfriendly_id?") { N.times { test_active_record_object.unfriendly_id? } }
 
-  x.report('hash friendly_id?') { N.times {test_hash.friendly_id?} }
-  x.report('hash unfriendly_id?') { N.times {test_hash.unfriendly_id?} }
+  x.report("hash friendly_id?") { N.times { test_hash.friendly_id? } }
+  x.report("hash unfriendly_id?") { N.times { test_hash.unfriendly_id? } }
 
-  x.report('nil friendly_id?') { N.times {test_nil.friendly_id?} }
-  x.report('nil unfriendly_id?') { N.times {test_nil.unfriendly_id?} }
+  x.report("nil friendly_id?") { N.times { test_nil.friendly_id? } }
+  x.report("nil unfriendly_id?") { N.times { test_nil.unfriendly_id? } }
 
-  x.report('numeric string friendly_id?') { N.times {test_numeric_string.friendly_id?} }
-  x.report('numeric string unfriendly_id?') { N.times {test_numeric_string.unfriendly_id?} }
+  x.report("numeric string friendly_id?") { N.times { test_numeric_string.friendly_id? } }
+  x.report("numeric string unfriendly_id?") { N.times { test_numeric_string.unfriendly_id? } }
 
-  x.report('test_string friendly_id?') { N.times {test_string.friendly_id?} }
-  x.report('test_string unfriendly_id?') { N.times {test_string.unfriendly_id?} }
+  x.report("test_string friendly_id?") { N.times { test_string.friendly_id? } }
+  x.report("test_string unfriendly_id?") { N.times { test_string.unfriendly_id? } }
 end

--- a/test/candidates_test.rb
+++ b/test/candidates_test.rb
@@ -1,8 +1,15 @@
 require "helper"
 
 class CandidatesTest < TestCaseClass
-
   include FriendlyId::Test
+
+  class Airport
+    def initialize(code)
+      @code = code
+    end
+    attr_reader :code
+    alias_method :to_s, :code
+  end
 
   class City < ActiveRecord::Base
     extend FriendlyId
@@ -16,8 +23,8 @@ class CandidatesTest < TestCaseClass
 
   def with_instances_of(klass = model_class, &block)
     transaction do
-      city1 = klass.create! :name => "New York", :code => "JFK"
-      city2 = klass.create! :name => "New York", :code => "EWR"
+      city1 = klass.create! name: "New York", code: "JFK"
+      city2 = klass.create! name: "New York", code: "EWR"
       yield city1, city2
     end
   end
@@ -26,7 +33,7 @@ class CandidatesTest < TestCaseClass
   test "resolves conflict with candidate" do
     with_instances do |city1, city2|
       assert_equal "new-york", city1.slug
-      assert_match(/\Anew-york-([a-z0-9]+\-){4}[a-z0-9]+\z/, city2.slug)
+      assert_match(/\Anew-york-([a-z0-9]+-){4}[a-z0-9]+\z/, city2.slug)
     end
   end
 
@@ -37,7 +44,7 @@ class CandidatesTest < TestCaseClass
       end
     end
     with_instances_of klass do |_, city|
-      assert_match(/\Anew-york-([a-z0-9]+\-){4}[a-z0-9]+\z/, city.slug)
+      assert_match(/\Anew-york-([a-z0-9]+-){4}[a-z0-9]+\z/, city.slug)
     end
   end
 
@@ -59,7 +66,7 @@ class CandidatesTest < TestCaseClass
       end
     end
     with_instances_of klass do |_, city|
-      assert_match(/\Anew-york-([a-z0-9]+\-){4}[a-z0-9]+\z/, city.slug)
+      assert_match(/\Anew-york-([a-z0-9]+-){4}[a-z0-9]+\z/, city.slug)
     end
   end
 
@@ -70,7 +77,7 @@ class CandidatesTest < TestCaseClass
       end
     end
     with_instances_of klass do |_, city|
-      assert_match(/\Anew-york-([a-z0-9]+\-){4}[a-z0-9]+\z/, city.slug)
+      assert_match(/\Anew-york-([a-z0-9]+-){4}[a-z0-9]+\z/, city.slug)
     end
   end
 
@@ -88,7 +95,7 @@ class CandidatesTest < TestCaseClass
   test "accepts candidate with lambda" do
     klass = Class.new City do
       def slug_candidates
-        [name, [name, ->{ rand 1000 }]]
+        [name, [name, -> { rand 1000 }]]
       end
     end
     with_instances_of klass do |_, city|
@@ -98,13 +105,6 @@ class CandidatesTest < TestCaseClass
 
   test "accepts candidate with object" do
     klass = Class.new City do
-      class Airport
-        def initialize(code)
-          @code = code
-        end
-        attr_reader :code
-        alias_method :to_s, :code
-      end
       def slug_candidates
         [name, [name, Airport.new(code)]]
       end
@@ -122,7 +122,7 @@ class CandidatesTest < TestCaseClass
     end
     with_instances_of klass do |_, city|
       candidates = FriendlyId::Candidates.new(city, city.slug_candidates)
-      assert_equal candidates.each, ['new-york']
+      assert_equal candidates.each, ["new-york"]
     end
   end
 
@@ -136,8 +136,7 @@ class CandidatesTest < TestCaseClass
       collected_candidates = []
       candidates = FriendlyId::Candidates.new(city, city.slug_candidates)
       candidates.each { |candidate| collected_candidates << candidate }
-      assert_equal collected_candidates, ['new-york']
+      assert_equal collected_candidates, ["new-york"]
     end
   end
-
 end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -1,7 +1,6 @@
 require "helper"
 
 class ConfigurationTest < TestCaseClass
-
   include FriendlyId::Test
 
   def setup
@@ -16,13 +15,13 @@ class ConfigurationTest < TestCaseClass
   end
 
   test "should set options on initialization if present" do
-    config = FriendlyId::Configuration.new @model_class, :base => "hello"
+    config = FriendlyId::Configuration.new @model_class, base: "hello"
     assert_equal "hello", config.base
   end
 
   test "should raise error if passed unrecognized option" do
     assert_raises NoMethodError do
-      FriendlyId::Configuration.new @model_class, :foo => "bar"
+      FriendlyId::Configuration.new @model_class, foo: "bar"
     end
   end
 
@@ -30,7 +29,7 @@ class ConfigurationTest < TestCaseClass
     refute @model_class < FriendlyId::Slugged
     @model_class.class_eval do
       extend FriendlyId
-      friendly_id :hello, :use => :slugged
+      friendly_id :hello, use: :slugged
     end
     assert @model_class < FriendlyId::Slugged
   end
@@ -40,7 +39,7 @@ class ConfigurationTest < TestCaseClass
     refute @model_class < my_module
     @model_class.class_eval do
       extend FriendlyId
-      friendly_id :hello, :use => my_module
+      friendly_id :hello, use: my_module
     end
     assert @model_class < my_module
   end
@@ -48,17 +47,14 @@ class ConfigurationTest < TestCaseClass
   test "#base should optionally set a value" do
     config = FriendlyId::Configuration.new @model_class
     assert_nil config.base
-    config.base = 'foo'
-    assert_equal 'foo', config.base
+    config.base = "foo"
+    assert_equal "foo", config.base
   end
 
   test "#base can set the value to nil" do
     config = FriendlyId::Configuration.new @model_class
-    config.base 'foo'
+    config.base "foo"
     config.base nil
     assert_nil config.base
-
   end
-
-
 end

--- a/test/core_test.rb
+++ b/test/core_test.rb
@@ -12,7 +12,6 @@ class Author < ActiveRecord::Base
 end
 
 class CoreTest < TestCaseClass
-
   include FriendlyId::Test
   include FriendlyId::Test::Shared::Core
 
@@ -31,6 +30,6 @@ class CoreTest < TestCaseClass
   end
 
   test "instances should have a friendly id" do
-    with_instance_of(model_class) {|record| assert record.friendly_id}
+    with_instance_of(model_class) { |record| assert record.friendly_id }
   end
 end

--- a/test/finders_test.rb
+++ b/test/finders_test.rb
@@ -1,27 +1,26 @@
 require "helper"
 
 class JournalistWithFriendlyFinders < ActiveRecord::Base
-  self.table_name = 'journalists'
+  self.table_name = "journalists"
   extend FriendlyId
-  scope :existing, -> {where('1 = 1')}
+  scope :existing, -> { where("1 = 1") }
   friendly_id :name, use: [:slugged, :finders]
 end
 
 class Finders < TestCaseClass
-
   include FriendlyId::Test
 
   def model_class
     JournalistWithFriendlyFinders
   end
 
-  test 'should find records with finders as class methods' do
+  test "should find records with finders as class methods" do
     with_instance_of(model_class) do |record|
       assert model_class.find(record.friendly_id)
     end
   end
 
-  test 'should find records with finders on relations' do
+  test "should find records with finders on relations" do
     with_instance_of(model_class) do |record|
       assert model_class.existing.find(record.friendly_id)
     end

--- a/test/generator_test.rb
+++ b/test/generator_test.rb
@@ -3,46 +3,36 @@ require "rails/generators"
 require "generators/friendly_id_generator"
 
 class FriendlyIdGeneratorTest < Rails::Generators::TestCase
-
   tests FriendlyIdGenerator
   destination File.expand_path("../../tmp", __FILE__)
 
   setup :prepare_destination
 
   test "should generate a migration" do
-    begin
-      run_generator
-      assert_migration "db/migrate/create_friendly_id_slugs"
-    ensure
-      FileUtils.rm_rf self.destination_root
-    end
+    run_generator
+    assert_migration "db/migrate/create_friendly_id_slugs"
+  ensure
+    FileUtils.rm_rf destination_root
   end
 
   test "should skip the migration when told to do so" do
-    begin
-      run_generator ['--skip-migration']
-      assert_no_migration "db/migrate/create_friendly_id_slugs"
-    ensure
-      FileUtils.rm_rf self.destination_root
-    end
+    run_generator ["--skip-migration"]
+    assert_no_migration "db/migrate/create_friendly_id_slugs"
+  ensure
+    FileUtils.rm_rf destination_root
   end
 
   test "should generate an initializer" do
-    begin
-      run_generator
-      assert_file "config/initializers/friendly_id.rb"
-    ensure
-      FileUtils.rm_rf self.destination_root
-    end
+    run_generator
+    assert_file "config/initializers/friendly_id.rb"
+  ensure
+    FileUtils.rm_rf destination_root
   end
 
   test "should skip the initializer when told to do so" do
-    begin
-      run_generator ['--skip-initializer']
-      assert_no_file "config/initializers/friendly_id.rb"
-    ensure
-      FileUtils.rm_rf self.destination_root
-    end
+    run_generator ["--skip-initializer"]
+    assert_no_file "config/initializers/friendly_id.rb"
+  ensure
+    FileUtils.rm_rf destination_root
   end
-
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,21 +1,21 @@
 require "bundler/setup"
 
-if ENV['COVERALLS'] || ENV['COVERAGE']
-  require 'simplecov'
-  if ENV['COVERALLS']
-    require 'coveralls'
+if ENV["COVERALLS"] || ENV["COVERAGE"]
+  require "simplecov"
+  if ENV["COVERALLS"]
+    require "coveralls"
     SimpleCov.formatter = Coveralls::SimpleCov::Formatter
   end
   SimpleCov.start do
-    add_filter 'test'
-    add_filter 'friendly_id/migration'
+    add_filter "test"
+    add_filter "friendly_id/migration"
   end
 end
 
 begin
-  require 'minitest'
+  require "minitest"
 rescue LoadError
-  require 'minitest/unit'
+  require "minitest/unit"
 end
 
 begin
@@ -26,8 +26,8 @@ end
 
 require "mocha/minitest"
 require "active_record"
-require 'active_support/core_ext/time/conversions'
-require 'erb'
+require "active_support/core_ext/time/conversions"
+require "erb"
 
 I18n.enforce_available_locales = false
 
@@ -39,29 +39,32 @@ if ENV["LOG"]
   ActiveRecord::Base.logger = Logger.new($stdout)
 end
 
-if ActiveSupport::VERSION::STRING >= '4.2'
+if ActiveSupport::VERSION::STRING >= "4.2"
   ActiveSupport.test_order = :random
 end
 
 module FriendlyId
   module Test
-
     def self.included(base)
       if Minitest.respond_to?(:autorun)
         Minitest.autorun
       else
-        require 'minitest/autorun'
+        require "minitest/autorun"
       end
     rescue LoadError
     end
 
     def transaction
-      ActiveRecord::Base.transaction { yield ; raise ActiveRecord::Rollback }
+      ActiveRecord::Base.transaction do
+        yield
+
+        raise ActiveRecord::Rollback
+      end
     end
 
     def with_instance_of(*args)
       model_class = args.shift
-      args[0] ||= {:name => "a b c"}
+      args[0] ||= {name: "a b c"}
       transaction { yield model_class.create!(*args) }
     end
 
@@ -70,7 +73,11 @@ module FriendlyId
 
       def connect
         version = ActiveRecord::VERSION::STRING
-        engine  = RUBY_ENGINE rescue "ruby"
+        engine = begin
+          RUBY_ENGINE
+        rescue
+          "ruby"
+        end
 
         ActiveRecord::Base.establish_connection config[driver]
         message = "Using #{engine} #{RUBY_VERSION} AR #{version} with #{driver}"
@@ -86,7 +93,7 @@ module FriendlyId
       end
 
       def config
-        @config ||= YAML::load(
+        @config ||= YAML.safe_load(
           ERB.new(
             File.read(File.expand_path("../databases.yml", __FILE__))
           ).result
@@ -94,9 +101,9 @@ module FriendlyId
       end
 
       def driver
-        _driver = ENV.fetch('DB', 'sqlite3').downcase
-        _driver = "postgres" if %w(postgresql pg).include?(_driver)
-        _driver
+        db_driver = ENV.fetch("DB", "sqlite3").downcase
+        db_driver = "postgres" if %w[postgresql pg].include?(db_driver)
+        db_driver
       end
 
       def in_memory?
@@ -115,4 +122,4 @@ end
 require "schema"
 require "shared"
 FriendlyId::Test::Database.connect
-at_exit {ActiveRecord::Base.connection.disconnect!}
+at_exit { ActiveRecord::Base.connection.disconnect! }

--- a/test/numeric_slug_test.rb
+++ b/test/numeric_slug_test.rb
@@ -1,4 +1,4 @@
-require 'helper'
+require "helper"
 
 class NumericSlugTest < TestCaseClass
   include FriendlyId::Test
@@ -10,21 +10,21 @@ class NumericSlugTest < TestCaseClass
 
   test "should generate numeric slugs" do
     transaction do
-      record = model_class.create! :name => "123"
+      record = model_class.create! name: "123"
       assert_equal "123", record.slug
     end
   end
 
   test "should find by numeric slug" do
     transaction do
-      record = model_class.create! :name => "123"
+      record = model_class.create! name: "123"
       assert_equal model_class.friendly.find("123").id, record.id
     end
   end
 
   test "should exist? by numeric slug" do
     transaction do
-      record = model_class.create! :name => "123"
+      model_class.create! name: "123"
       assert model_class.friendly.exists?("123")
     end
   end

--- a/test/object_utils_test.rb
+++ b/test/object_utils_test.rb
@@ -1,8 +1,6 @@
 require "helper"
 
-
 class ObjectUtilsTest < TestCaseClass
-
   include FriendlyId::Test
 
   test "strings with letters are friendly_ids" do

--- a/test/reserved_test.rb
+++ b/test/reserved_test.rb
@@ -1,12 +1,11 @@
 require "helper"
 
 class ReservedTest < TestCaseClass
-
   include FriendlyId::Test
 
   class Journalist < ActiveRecord::Base
     extend FriendlyId
-    friendly_id :slug_candidates, :use => [:slugged, :reserved], :reserved_words => %w(new edit)
+    friendly_id :slug_candidates, use: [:slugged, :reserved], reserved_words: %w[new edit]
 
     after_validation :move_friendly_id_error_to_name
 
@@ -24,9 +23,9 @@ class ReservedTest < TestCaseClass
   end
 
   test "should reserve words" do
-    %w(new edit NEW Edit).each do |word|
+    %w[new edit NEW Edit].each do |word|
       transaction do
-        assert_raises(ActiveRecord::RecordInvalid) {model_class.create! :name => word}
+        assert_raises(ActiveRecord::RecordInvalid) { model_class.create! name: word }
       end
     end
   end
@@ -43,7 +42,7 @@ class ReservedTest < TestCaseClass
 
   test "should reject reserved candidates" do
     transaction do
-      record = model_class.new(:name => 'new')
+      record = model_class.new(name: "new")
       def record.slug_candidates
         [:name, "foo"]
       end
@@ -54,22 +53,21 @@ class ReservedTest < TestCaseClass
 
   test "should be invalid if all candidates are reserved" do
     transaction do
-      record = model_class.new(:name => 'new')
+      record = model_class.new(name: "new")
       def record.slug_candidates
         ["edit", "new"]
       end
-      assert_raises(ActiveRecord::RecordInvalid) {record.save!}
+      assert_raises(ActiveRecord::RecordInvalid) { record.save! }
     end
   end
 
   test "should optionally treat reserved words as conflict" do
     klass = Class.new(model_class) do
-      friendly_id :slug_candidates, :use => [:slugged, :reserved], :reserved_words => %w(new edit), :treat_reserved_as_conflict => true
+      friendly_id :slug_candidates, use: [:slugged, :reserved], reserved_words: %w[new edit], treat_reserved_as_conflict: true
     end
 
-    with_instance_of(klass, name: 'new') do |record|
-      assert_match(/new-([0-9a-z]+\-){4}[0-9a-z]+\z/, record.slug)
+    with_instance_of(klass, name: "new") do |record|
+      assert_match(/new-([0-9a-z]+-){4}[0-9a-z]+\z/, record.slug)
     end
   end
-
 end

--- a/test/schema.rb
+++ b/test/schema.rb
@@ -25,7 +25,7 @@ module FriendlyId
 
           tables.each do |table_name|
             create_table table_name do |t|
-              t.string  :name
+              t.string :name
               t.boolean :active
             end
           end
@@ -41,7 +41,7 @@ module FriendlyId
 
           slugged_tables.each do |table_name|
             add_column table_name, :slug, :string
-            add_index  table_name, :slug, :unique => true if 'novels' != table_name
+            add_index table_name, :slug, unique: true if table_name != "novels"
           end
 
           scoped_tables.each do |table_name|
@@ -57,7 +57,7 @@ module FriendlyId
           # This will be used to test scopes
           add_column :novels, :novelist_id, :integer
           add_column :novels, :publisher_id, :integer
-          add_index :novels, [:slug, :publisher_id, :novelist_id], :unique => true
+          add_index :novels, [:slug, :publisher_id, :novelist_id], unique: true
 
           # This will be used to test column name quoting
           add_column :journalists, "strange name", :string
@@ -78,7 +78,7 @@ module FriendlyId
           add_column :restaurants, :city_id, :integer
 
           # Used to test candidates
-          add_column :cities, :code, :string, :limit => 3
+          add_column :cities, :code, :string, limit: 3
 
           # Used as a non-default slug_column
           add_column :authors, :subdomain, :string

--- a/test/scoped_test.rb
+++ b/test/scoped_test.rb
@@ -2,14 +2,14 @@ require "helper"
 
 class Novelist < ActiveRecord::Base
   extend FriendlyId
-  friendly_id :name, :use => :slugged
+  friendly_id :name, use: :slugged
 end
 
 class Novel < ActiveRecord::Base
   extend FriendlyId
   belongs_to :novelist
   belongs_to :publisher
-  friendly_id :name, :use => :scoped, :scope => [:publisher, :novelist]
+  friendly_id :name, use: :scoped, scope: [:publisher, :novelist]
 
   def should_generate_new_friendly_id?
     new_record? || super
@@ -21,7 +21,6 @@ class Publisher < ActiveRecord::Base
 end
 
 class ScopedTest < TestCaseClass
-
   include FriendlyId::Test
   include FriendlyId::Test::Shared::Core
 
@@ -37,42 +36,42 @@ class ScopedTest < TestCaseClass
     model_class = Class.new(ActiveRecord::Base) do
       self.abstract_class = true
       extend FriendlyId
-      friendly_id :empty, :use => :scoped, :scope => :dummy
+      friendly_id :empty, use: :scoped, scope: :dummy
     end
     assert_equal ["dummy"], model_class.friendly_id_config.scope_columns
   end
 
   test "should allow duplicate slugs outside scope" do
     transaction do
-      novel1 = Novel.create! :name => "a", :novelist => Novelist.create!(:name => "a")
-      novel2 = Novel.create! :name => "a", :novelist => Novelist.create!(:name => "b")
+      novel1 = Novel.create! name: "a", novelist: Novelist.create!(name: "a")
+      novel2 = Novel.create! name: "a", novelist: Novelist.create!(name: "b")
       assert_equal novel1.friendly_id, novel2.friendly_id
     end
   end
 
   test "should not allow duplicate slugs inside scope" do
     with_instance_of Novelist do |novelist|
-      novel1 = Novel.create! :name => "a", :novelist => novelist
-      novel2 = Novel.create! :name => "a", :novelist => novelist
+      novel1 = Novel.create! name: "a", novelist: novelist
+      novel2 = Novel.create! name: "a", novelist: novelist
       assert novel1.friendly_id != novel2.friendly_id
     end
   end
 
   test "should apply scope with multiple columns" do
     transaction do
-      novelist = Novelist.create! :name => "a"
-      publisher = Publisher.create! :name => "b"
-      novel1 = Novel.create! :name => "c", :novelist => novelist, :publisher => publisher
-      novel2 = Novel.create! :name => "c", :novelist => novelist, :publisher => Publisher.create(:name => "d")
-      novel3 = Novel.create! :name => "c", :novelist => Novelist.create(:name => "e"), :publisher => publisher
-      novel4 = Novel.create! :name => "c", :novelist => novelist, :publisher => publisher
+      novelist = Novelist.create! name: "a"
+      publisher = Publisher.create! name: "b"
+      novel1 = Novel.create! name: "c", novelist: novelist, publisher: publisher
+      novel2 = Novel.create! name: "c", novelist: novelist, publisher: Publisher.create(name: "d")
+      novel3 = Novel.create! name: "c", novelist: Novelist.create(name: "e"), publisher: publisher
+      novel4 = Novel.create! name: "c", novelist: novelist, publisher: publisher
       assert_equal novel1.friendly_id, novel2.friendly_id
       assert_equal novel2.friendly_id, novel3.friendly_id
       assert novel3.friendly_id != novel4.friendly_id
     end
   end
 
-  test 'should allow a record to reuse its own slug' do
+  test "should allow a record to reuse its own slug" do
     with_instance_of(model_class) do |record|
       old_id = record.friendly_id
       record.slug = nil
@@ -83,15 +82,14 @@ class ScopedTest < TestCaseClass
 
   test "should generate new slug when scope changes" do
     transaction do
-      novelist = Novelist.create! :name => "a"
-      publisher = Publisher.create! :name => "b"
-      novel1 = Novel.create! :name => "c", :novelist => novelist, :publisher => publisher
-      novel2 = Novel.create! :name => "c", :novelist => novelist, :publisher => Publisher.create(:name => "d")
+      novelist = Novelist.create! name: "a"
+      publisher = Publisher.create! name: "b"
+      novel1 = Novel.create! name: "c", novelist: novelist, publisher: publisher
+      novel2 = Novel.create! name: "c", novelist: novelist, publisher: Publisher.create(name: "d")
       assert_equal novel1.friendly_id, novel2.friendly_id
       novel2.publisher = publisher
       novel2.save!
       assert novel2.friendly_id != novel1.friendly_id
     end
   end
-
 end

--- a/test/sequentially_slugged_test.rb
+++ b/test/sequentially_slugged_test.rb
@@ -1,8 +1,8 @@
-require 'helper'
+require "helper"
 
 class Article < ActiveRecord::Base
   extend FriendlyId
-  friendly_id :name, :use => :sequentially_slugged
+  friendly_id :name, use: :sequentially_slugged
 end
 
 class SequentiallySluggedTest < TestCaseClass
@@ -15,27 +15,27 @@ class SequentiallySluggedTest < TestCaseClass
 
   test "should generate numerically sequential slugs" do
     transaction do
-      records = 12.times.map { model_class.create! :name => "Some news" }
+      records = 12.times.map { model_class.create! name: "Some news" }
       assert_equal "some-news", records[0].slug
-      (1...12).each {|i| assert_equal "some-news-#{i + 1}", records[i].slug}
+      (1...12).each { |i| assert_equal "some-news-#{i + 1}", records[i].slug }
     end
   end
 
   test "should cope when slugs are missing from the sequence" do
     transaction do
-      record_1 = model_class.create!(:name => 'A thing')
-      record_2 = model_class.create!(:name => 'A thing')
-      record_3 = model_class.create!(:name => 'A thing')
+      record_1 = model_class.create!(name: "A thing")
+      record_2 = model_class.create!(name: "A thing")
+      record_3 = model_class.create!(name: "A thing")
 
-      assert_equal 'a-thing', record_1.slug
-      assert_equal 'a-thing-2', record_2.slug
-      assert_equal 'a-thing-3', record_3.slug
+      assert_equal "a-thing", record_1.slug
+      assert_equal "a-thing-2", record_2.slug
+      assert_equal "a-thing-3", record_3.slug
 
       record_2.destroy
 
-      record_4 = model_class.create!(:name => 'A thing')
+      record_4 = model_class.create!(name: "A thing")
 
-      assert_equal 'a-thing-4', record_4.slug
+      assert_equal "a-thing-4", record_4.slug
     end
   end
 
@@ -43,32 +43,32 @@ class SequentiallySluggedTest < TestCaseClass
     model_class = Class.new(ActiveRecord::Base) do
       self.table_name = "journalists"
       extend FriendlyId
-      friendly_id :name, :use => :sequentially_slugged, :slug_column => "strange name"
+      friendly_id :name, use: :sequentially_slugged, slug_column: "strange name"
     end
 
     transaction do
-      record_1 = model_class.create! name: "Julian Assange"
-      record_2 = model_class.create! name: "Julian Assange"
+      record_1 = model_class.create! name: "Lois Lane"
+      record_2 = model_class.create! name: "Lois Lane"
 
-      assert_equal 'julian-assange', record_1.attributes["strange name"]
-      assert_equal 'julian-assange-2', record_2.attributes["strange name"]
+      assert_equal "lois-lane", record_1.attributes["strange name"]
+      assert_equal "lois-lane-2", record_2.attributes["strange name"]
     end
   end
 
   test "should correctly sequence slugs that end in a number" do
     transaction do
-      record1 = model_class.create! :name => "Peugeuot 206"
+      record1 = model_class.create! name: "Peugeuot 206"
       assert_equal "peugeuot-206", record1.slug
-      record2 = model_class.create! :name => "Peugeuot 206"
+      record2 = model_class.create! name: "Peugeuot 206"
       assert_equal "peugeuot-206-2", record2.slug
     end
   end
 
   test "should correctly sequence slugs that begin with a number" do
     transaction do
-      record1 = model_class.create! :name => "2010 to 2015 Records"
+      record1 = model_class.create! name: "2010 to 2015 Records"
       assert_equal "2010-to-2015-records", record1.slug
-      record2 = model_class.create! :name => "2010 to 2015 Records"
+      record2 = model_class.create! name: "2010 to 2015 Records"
       assert_equal "2010-to-2015-records-2", record2.slug
     end
   end
@@ -77,15 +77,15 @@ class SequentiallySluggedTest < TestCaseClass
     model_class = Class.new(ActiveRecord::Base) do
       self.table_name = "novelists"
       extend FriendlyId
-      friendly_id :name, :use => :sequentially_slugged, :sequence_separator => ':'
+      friendly_id :name, use: :sequentially_slugged, sequence_separator: ":"
     end
 
     transaction do
       record_1 = model_class.create! name: "Julian Barnes"
       record_2 = model_class.create! name: "Julian Barnes"
 
-      assert_equal 'julian-barnes', record_1.slug
-      assert_equal 'julian-barnes:2', record_2.slug
+      assert_equal "julian-barnes", record_1.slug
+      assert_equal "julian-barnes:2", record_2.slug
     end
   end
 
@@ -93,20 +93,20 @@ class SequentiallySluggedTest < TestCaseClass
     model_class = Class.new(ActiveRecord::Base) do
       self.table_name = "cities"
       extend FriendlyId
-      friendly_id :slug_candidates, :use => [ :sequentially_slugged ]
+      friendly_id :slug_candidates, use: [:sequentially_slugged]
 
       def slug_candidates
         [name, [name, code]]
       end
     end
     transaction do
-      record = model_class.create!(:name => nil, :code => nil)
+      record = model_class.create!(name: nil, code: nil)
       assert_nil record.slug
     end
   end
 
   test "should not generate a slug when the sluggable attribute is blank" do
-    record = model_class.create!(:name => '')
+    record = model_class.create!(name: "")
     assert_nil record.slug
   end
 end
@@ -117,7 +117,12 @@ class SequentiallySluggedTestWithHistory < TestCaseClass
 
   class Article < ActiveRecord::Base
     extend FriendlyId
-    friendly_id :name, :use => [:sequentially_slugged, :history]
+    friendly_id :name, use: [:sequentially_slugged, :history]
+  end
+
+  Journalist = Class.new(ActiveRecord::Base) do
+    extend FriendlyId
+    friendly_id :name, use: [:sequentially_slugged, :history], slug_column: "strange name"
   end
 
   def model_class
@@ -126,51 +131,46 @@ class SequentiallySluggedTestWithHistory < TestCaseClass
 
   test "should work with regeneration with history when slug already exists" do
     transaction do
-      record1 = model_class.create! :name => "Test name"
-      record2 = model_class.create! :name => "Another test name"
-      assert_equal 'test-name', record1.slug
-      assert_equal 'another-test-name', record2.slug
+      record1 = model_class.create! name: "Test name"
+      record2 = model_class.create! name: "Another test name"
+      assert_equal "test-name", record1.slug
+      assert_equal "another-test-name", record2.slug
 
       record2.name = "Test name"
       record2.slug = nil
       record2.save!
-      assert_equal 'test-name-2', record2.slug
+      assert_equal "test-name-2", record2.slug
     end
   end
 
   test "should work with regeneration with history when 2 slugs already exists and the second is changed" do
     transaction do
-      record1 = model_class.create! :name => "Test name"
-      record2 = model_class.create! :name => "Test name"
-      record3 = model_class.create! :name => "Another test name"
-      assert_equal 'test-name', record1.slug
-      assert_equal 'test-name-2', record2.slug
-      assert_equal 'another-test-name', record3.slug
+      record1 = model_class.create! name: "Test name"
+      record2 = model_class.create! name: "Test name"
+      record3 = model_class.create! name: "Another test name"
+      assert_equal "test-name", record1.slug
+      assert_equal "test-name-2", record2.slug
+      assert_equal "another-test-name", record3.slug
 
       record2.name = "One more test name"
       record2.slug = nil
       record2.save!
-      assert_equal 'one-more-test-name', record2.slug
+      assert_equal "one-more-test-name", record2.slug
 
       record3.name = "Test name"
       record3.slug = nil
       record3.save!
-      assert_equal 'test-name-3', record3.slug
+      assert_equal "test-name-3", record3.slug
     end
   end
 
   test "should cope with strange column names" do
-    Journalist = Class.new(ActiveRecord::Base) do
-      extend FriendlyId
-      friendly_id :name, :use => [:sequentially_slugged, :history], :slug_column => "strange name"
-    end
-
     transaction do
-      record_1 = Journalist.create! name: "Julian Assange"
-      record_2 = Journalist.create! name: "Julian Assange"
+      record_1 = Journalist.create! name: "Lois Lane"
+      record_2 = Journalist.create! name: "Lois Lane"
 
-      assert_equal 'julian-assange', record_1.attributes["strange name"]
-      assert_equal 'julian-assange-2', record_2.attributes["strange name"]
+      assert_equal "lois-lane", record_1.attributes["strange name"]
+      assert_equal "lois-lane-2", record_2.attributes["strange name"]
     end
   end
 end
@@ -182,7 +182,7 @@ end
 class Restaurant < ActiveRecord::Base
   extend FriendlyId
   belongs_to :city
-  friendly_id :name, :use => [:sequentially_slugged, :scoped, :history], :scope => :city
+  friendly_id :name, use: [:sequentially_slugged, :scoped, :history], scope: :city
 end
 
 class SequentiallySluggedTestWithScopedHistory < TestCaseClass
@@ -196,19 +196,19 @@ class SequentiallySluggedTestWithScopedHistory < TestCaseClass
   test "should work with regeneration with scoped history" do
     transaction do
       city1 = City.create!
-      city2 = City.create!
-      record1 = model_class.create! :name => "Test name", :city => city1
-      record2 = model_class.create! :name => "Test name", :city => city1
+      City.create!
+      record1 = model_class.create! name: "Test name", city: city1
+      record2 = model_class.create! name: "Test name", city: city1
 
-      assert_equal 'test-name', record1.slug
-      assert_equal 'test-name-2', record2.slug
+      assert_equal "test-name", record1.slug
+      assert_equal "test-name-2", record2.slug
 
-      record2.name = 'Another test name'
+      record2.name = "Another test name"
       record2.slug = nil
       record2.save!
 
-      record3 = model_class.create! :name => "Test name", :city => city1
-      assert_equal 'test-name-3', record3.slug
+      record3 = model_class.create! name: "Test name", city: city1
+      assert_equal "test-name-3", record3.slug
     end
   end
 end

--- a/test/shared.rb
+++ b/test/shared.rb
@@ -1,7 +1,6 @@
 module FriendlyId
   module Test
     module Shared
-
       module Slugged
         test "configuration should have a sequence_separator" do
           assert !model_class.friendly_id_config.sequence_separator.empty?
@@ -18,15 +17,15 @@ module FriendlyId
 
         test "should add a UUID for duplicate friendly ids" do
           with_instance_of model_class do |record|
-            record2 = model_class.create! :name => record.name
-            assert record2.friendly_id.match(/([0-9a-z]+\-){4}[0-9a-z]+\z/)
+            record2 = model_class.create! name: record.name
+            assert record2.friendly_id.match(/([0-9a-z]+-){4}[0-9a-z]+\z/)
           end
         end
 
         test "should not add slug sequence on update after other conflicting slugs were added" do
           with_instance_of model_class do |record|
             old = record.friendly_id
-            model_class.create! :name => record.name
+            model_class.create! name: record.name
             record.save!
             record.reload
             assert_equal old, record.to_param
@@ -35,7 +34,7 @@ module FriendlyId
 
         test "should not change the sequence on save" do
           with_instance_of model_class do |record|
-            record2 = model_class.create! :name => record.name
+            record2 = model_class.create! name: record.name
             friendly_id = record2.friendly_id
             record2.active = !record2.active
             record2.save!
@@ -64,7 +63,7 @@ module FriendlyId
           with_instance_of my_model_class do |record|
             record.update my_model_class.friendly_id_config.slug_column => nil
             record = my_model_class.friendly.find(record.id)
-            record.class.validate Proc.new {errors.add(:name, "FAIL")}
+            record.class.validate proc { errors.add(:name, "FAIL") }
             record.save
             assert_equal record.to_param, record.friendly_id
           end
@@ -84,7 +83,7 @@ module FriendlyId
         end
 
         test "should be findable by friendly id" do
-          with_instance_of(model_class) {|record| assert model_class.friendly.find record.friendly_id}
+          with_instance_of(model_class) { |record| assert model_class.friendly.find record.friendly_id }
         end
 
         test "should exist? by friendly id" do
@@ -92,19 +91,19 @@ module FriendlyId
             assert model_class.friendly.exists? record.id
             assert model_class.friendly.exists? record.id.to_s
             assert model_class.friendly.exists? record.friendly_id
-            assert model_class.friendly.exists?({:id => record.id})
-            assert model_class.friendly.exists?(['id = ?', record.id])
+            assert model_class.friendly.exists?({id: record.id})
+            assert model_class.friendly.exists?(["id = ?", record.id])
             assert !model_class.friendly.exists?(record.friendly_id + "-hello")
             assert !model_class.friendly.exists?(0)
           end
         end
 
         test "should be findable by id as integer" do
-          with_instance_of(model_class) {|record| assert model_class.friendly.find record.id.to_i}
+          with_instance_of(model_class) { |record| assert model_class.friendly.find record.id.to_i }
         end
 
         test "should be findable by id as string" do
-          with_instance_of(model_class) {|record| assert model_class.friendly.find record.id.to_s}
+          with_instance_of(model_class) { |record| assert model_class.friendly.find record.id.to_s }
         end
 
         test "should treat numeric part of string as an integer id" do
@@ -116,16 +115,16 @@ module FriendlyId
         end
 
         test "should be findable by numeric friendly_id" do
-          with_instance_of(model_class, :name => "206") {|record| assert model_class.friendly.find record.friendly_id}
+          with_instance_of(model_class, name: "206") { |record| assert model_class.friendly.find record.friendly_id }
         end
 
         test "to_param should return the friendly_id" do
-          with_instance_of(model_class) {|record| assert_equal record.friendly_id, record.to_param}
+          with_instance_of(model_class) { |record| assert_equal record.friendly_id, record.to_param }
         end
 
         if ActiveRecord::VERSION::MAJOR == 4 && ActiveRecord::VERSION::MINOR < 2
           test "should be findable by themselves" do
-            with_instance_of(model_class) {|record| assert_equal record, model_class.friendly.find(record)}
+            with_instance_of(model_class) { |record| assert_equal record, model_class.friendly.find(record) }
           end
         end
 
@@ -138,11 +137,11 @@ module FriendlyId
         end
 
         test "instances found by a single id should not be read-only" do
-          with_instance_of(model_class) {|record| assert !model_class.friendly.find(record.friendly_id).readonly?}
+          with_instance_of(model_class) { |record| assert !model_class.friendly.find(record.friendly_id).readonly? }
         end
 
         test "failing finds with unfriendly_id should raise errors normally" do
-          assert_raises(ActiveRecord::RecordNotFound) {model_class.friendly.find 0}
+          assert_raises(ActiveRecord::RecordNotFound) { model_class.friendly.find 0 }
         end
 
         test "should return numeric id if the friendly_id is nil" do

--- a/test/simple_i18n_test.rb
+++ b/test/simple_i18n_test.rb
@@ -5,7 +5,7 @@ class SimpleI18nTest < TestCaseClass
 
   class Journalist < ActiveRecord::Base
     extend FriendlyId
-    friendly_id :name, :use => :simple_i18n
+    friendly_id :name, use: :simple_i18n
   end
 
   def setup
@@ -13,7 +13,7 @@ class SimpleI18nTest < TestCaseClass
   end
 
   test "friendly_id should return the current locale's slug" do
-    journalist = Journalist.new(:name => "John Doe")
+    journalist = Journalist.new(name: "John Doe")
     journalist.slug_es = "juan-fulano"
     journalist.slug_fr_ca = "jean-dupont"
     journalist.valid?
@@ -30,13 +30,13 @@ class SimpleI18nTest < TestCaseClass
 
   test "should create record with slug in column for the current locale" do
     I18n.with_locale(I18n.default_locale) do
-      journalist = Journalist.new(:name => "John Doe")
+      journalist = Journalist.new(name: "John Doe")
       journalist.valid?
       assert_equal "john-doe", journalist.slug_en
       assert_nil journalist.slug_es
     end
     I18n.with_locale(:es) do
-      journalist = Journalist.new(:name => "John Doe")
+      journalist = Journalist.new(name: "John Doe")
       journalist.valid?
       assert_equal "john-doe", journalist.slug_es
       assert_nil journalist.slug_en
@@ -45,7 +45,7 @@ class SimpleI18nTest < TestCaseClass
 
   test "to_param should return the numeric id when there's no slug for the current locale" do
     transaction do
-      journalist = Journalist.new(:name => "Juan Fulano")
+      journalist = Journalist.new(name: "Juan Fulano")
       I18n.with_locale(:es) do
         journalist.save!
         assert_equal "juan-fulano", journalist.to_param
@@ -56,7 +56,7 @@ class SimpleI18nTest < TestCaseClass
 
   test "should set friendly id for locale" do
     transaction do
-      journalist = Journalist.create!(:name => "John Smith")
+      journalist = Journalist.create!(name: "John Smith")
       journalist.set_friendly_id("Juan Fulano", :es)
       journalist.save!
       assert_equal "juan-fulano", journalist.slug_es
@@ -69,7 +69,7 @@ class SimpleI18nTest < TestCaseClass
   test "set friendly_id should fall back default locale when none is given" do
     transaction do
       journalist = I18n.with_locale(:es) do
-        Journalist.create!(:name => "Juan Fulano")
+        Journalist.create!(name: "Juan Fulano")
       end
       journalist.set_friendly_id("John Doe")
       journalist.save!
@@ -79,9 +79,9 @@ class SimpleI18nTest < TestCaseClass
 
   test "should sequence localized slugs" do
     transaction do
-      journalist = Journalist.create!(:name => "John Smith")
+      journalist = Journalist.create!(name: "John Smith")
       I18n.with_locale(:es) do
-        Journalist.create!(:name => "Juan Fulano")
+        Journalist.create!(name: "Juan Fulano")
       end
       journalist.set_friendly_id("Juan Fulano", :es)
       journalist.save!
@@ -97,12 +97,12 @@ class SimpleI18nTest < TestCaseClass
 
     test "should not overwrite other locale's slugs on update" do
       transaction do
-        journalist = Journalist.create!(:name => "John Smith")
+        journalist = Journalist.create!(name: "John Smith")
         journalist.set_friendly_id("Juan Fulano", :es)
         journalist.save!
         assert_equal "john-smith", journalist.to_param
         journalist.slug = nil
-        journalist.update :name => "Johnny Smith"
+        journalist.update name: "Johnny Smith"
         assert_equal "johnny-smith", journalist.to_param
         I18n.with_locale(:es) do
           assert_equal "juan-fulano", journalist.to_param
@@ -128,7 +128,7 @@ class SimpleI18nTest < TestCaseClass
       model_class = Class.new(ActiveRecord::Base) do
         self.abstract_class = true
         extend FriendlyId
-        friendly_id :name, :use => :simple_i18n, :slug_column => :foo
+        friendly_id :name, use: :simple_i18n, slug_column: :foo
       end
       I18n.with_locale :es do
         assert_equal "foo_es", model_class.friendly_id_config.slug_column

--- a/test/slugged_test.rb
+++ b/test/slugged_test.rb
@@ -2,25 +2,24 @@ require "helper"
 
 class Journalist < ActiveRecord::Base
   extend FriendlyId
-  friendly_id :name, :use => :slugged
+  friendly_id :name, use: :slugged
 end
 
 class Article < ActiveRecord::Base
   extend FriendlyId
-  friendly_id :name, :use => :slugged
+  friendly_id :name, use: :slugged
 end
 
 class Novelist < ActiveRecord::Base
   extend FriendlyId
-  friendly_id :name, :use => :slugged, :sequence_separator => '_'
+  friendly_id :name, use: :slugged, sequence_separator: "_"
 
   def normalize_friendly_id(string)
-    super.gsub("-", "_")
+    super.tr("-", "_")
   end
 end
 
 class SluggedTest < TestCaseClass
-
   include FriendlyId::Test
   include FriendlyId::Test::Shared::Core
   include FriendlyId::Test::Shared::Slugged
@@ -33,13 +32,13 @@ class SluggedTest < TestCaseClass
     model_class = Class.new(ActiveRecord::Base) do
       self.table_name = "articles"
       extend FriendlyId
-      friendly_id :name, :use => :slugged
-      validates_length_of :slug, :maximum => 1
+      friendly_id :name, use: :slugged
+      validates_length_of :slug, maximum: 1
       def self.name
         "Article"
       end
     end
-    instance = model_class.new :name => "hello"
+    instance = model_class.new name: "hello"
     refute instance.valid?
   end
 
@@ -55,21 +54,21 @@ class SluggedTest < TestCaseClass
     model_class = Class.new(ActiveRecord::Base) do
       self.table_name = "journalists"
       extend FriendlyId
-      friendly_id :name, :use => :slugged
+      friendly_id :name, use: :slugged
       validates_uniqueness_of :slug_en
       def self.name
         "Journalist"
       end
     end
     transaction do
-      instance = model_class.create! :name => "hello", :slug_en => "hello"
-      instance2 = model_class.create :name => "hello", :slug_en => "hello"
+      instance = model_class.create! name: "hello", slug_en: "hello"
+      instance2 = model_class.create name: "hello", slug_en: "hello"
       assert instance.valid?
       refute instance2.valid?
     end
   end
 
-  test 'should allow a record to reuse its own slug' do
+  test "should allow a record to reuse its own slug" do
     with_instance_of(model_class) do |record|
       old_id = record.friendly_id
       record.slug = nil
@@ -95,7 +94,7 @@ class SluggedTest < TestCaseClass
   test "should set slug on create if unrelated validations fail" do
     klass = Class.new model_class do
       validates_presence_of :active
-      friendly_id :name, :use => :slugged
+      friendly_id :name, use: :slugged
 
       def self.name
         "Journalist"
@@ -103,18 +102,18 @@ class SluggedTest < TestCaseClass
     end
 
     transaction do
-      instance = klass.new :name => 'foo'
+      instance = klass.new name: "foo"
       refute instance.save
       refute instance.valid?
-      assert_equal 'foo', instance.slug
+      assert_equal "foo", instance.slug
     end
   end
 
   test "should not set slug on create if slug validation fails" do
     klass = Class.new model_class do
       validates_presence_of :active
-      validates_length_of :slug, :minimum => 2
-      friendly_id :name, :use => :slugged
+      validates_length_of :slug, minimum: 2
+      friendly_id :name, use: :slugged
 
       def self.name
         "Journalist"
@@ -122,7 +121,7 @@ class SluggedTest < TestCaseClass
     end
 
     transaction do
-      instance = klass.new :name => 'x'
+      instance = klass.new name: "x"
       refute instance.save
       refute instance.valid?
       assert_nil instance.slug
@@ -131,10 +130,10 @@ class SluggedTest < TestCaseClass
 
   test "should set slug on create if unrelated validations fail with custom slug_column" do
     klass = Class.new(ActiveRecord::Base) do
-      self.table_name = 'authors'
+      self.table_name = "authors"
       extend FriendlyId
       validates_presence_of :active
-      friendly_id :name, :use => :slugged, :slug_column => :subdomain
+      friendly_id :name, use: :slugged, slug_column: :subdomain
 
       def self.name
         "Author"
@@ -142,19 +141,19 @@ class SluggedTest < TestCaseClass
     end
 
     transaction do
-      instance = klass.new :name => 'foo'
+      instance = klass.new name: "foo"
       refute instance.save
       refute instance.valid?
-      assert_equal 'foo', instance.subdomain
+      assert_equal "foo", instance.subdomain
     end
   end
 
   test "should not set slug on create if custom slug column validations fail" do
     klass = Class.new(ActiveRecord::Base) do
-      self.table_name = 'authors'
+      self.table_name = "authors"
       extend FriendlyId
-      validates_length_of :subdomain, :minimum => 2
-      friendly_id :name, :use => :slugged, :slug_column => :subdomain
+      validates_length_of :subdomain, minimum: 2
+      friendly_id :name, use: :slugged, slug_column: :subdomain
 
       def self.name
         "Author"
@@ -162,7 +161,7 @@ class SluggedTest < TestCaseClass
     end
 
     transaction do
-      instance = klass.new :name => 'x'
+      instance = klass.new name: "x"
       refute instance.save
       refute instance.valid?
       assert_nil instance.subdomain
@@ -172,7 +171,7 @@ class SluggedTest < TestCaseClass
   test "should keep new slug on save if unrelated validations fail" do
     klass = Class.new model_class do
       validates_presence_of :active
-      friendly_id :name, :use => :slugged
+      friendly_id :name, use: :slugged
 
       def self.name
         "Journalist"
@@ -180,22 +179,22 @@ class SluggedTest < TestCaseClass
     end
 
     transaction do
-      instance = klass.new :name => 'foo', :active => true
+      instance = klass.new name: "foo", active: true
       assert instance.save
       assert instance.valid?
-      instance.name = 'foobar'
+      instance.name = "foobar"
       instance.slug = nil
       instance.active = nil
       refute instance.save
       refute instance.valid?
-      assert_equal 'foobar', instance.slug
+      assert_equal "foobar", instance.slug
     end
   end
 
   test "should not update slug on save if slug validations fail" do
     klass = Class.new model_class do
-      validates_length_of :slug, :minimum => 2
-      friendly_id :name, :use => :slugged
+      validates_length_of :slug, minimum: 2
+      friendly_id :name, use: :slugged
 
       def self.name
         "Journalist"
@@ -203,20 +202,19 @@ class SluggedTest < TestCaseClass
     end
 
     transaction do
-      instance = klass.new :name => 'foo', :active => true
+      instance = klass.new name: "foo", active: true
       assert instance.save
       assert instance.valid?
-      instance.name = 'x'
+      instance.name = "x"
       instance.slug = nil
       instance.active = nil
       refute instance.save
-      assert_equal 'foo', instance.slug
+      assert_equal "foo", instance.slug
     end
   end
 end
 
 class SlugGeneratorTest < TestCaseClass
-
   include FriendlyId::Test
 
   def model_class
@@ -232,11 +230,11 @@ class SlugGeneratorTest < TestCaseClass
       # self.abstract_class = true
       self.table_name = "journalists"
       extend FriendlyId
-      friendly_id :name, :use => :slugged, :slug_column => "strange name"
+      friendly_id :name, use: :slugged, slug_column: "strange name"
     end
 
     begin
-      with_instance_of(model_class) {|record| assert model_class.friendly.find(record.friendly_id)}
+      with_instance_of(model_class) { |record| assert model_class.friendly.find(record.friendly_id) }
     rescue ActiveRecord::StatementInvalid
       flunk "column name was not quoted"
     end
@@ -244,9 +242,9 @@ class SlugGeneratorTest < TestCaseClass
 
   test "should not resequence lower sequences on update" do
     transaction do
-      m1 = model_class.create! :name => "a b c d"
+      m1 = model_class.create! name: "a b c d"
       assert_equal "a-b-c-d", m1.slug
-      model_class.create! :name => "a b c d"
+      model_class.create! name: "a b c d"
       m1 = model_class.friendly.find(m1.id)
       m1.save!
       assert_equal "a-b-c-d", m1.slug
@@ -255,37 +253,35 @@ class SlugGeneratorTest < TestCaseClass
 
   test "should correctly sequence slugs that end with numbers" do
     transaction do
-      record1 = model_class.create! :name => "Peugeot 206"
+      record1 = model_class.create! name: "Peugeot 206"
       assert_equal "peugeot-206", record1.slug
-      record2 = model_class.create! :name => "Peugeot 206"
-      assert_match(/\Apeugeot-206-([a-z0-9]+\-){4}[a-z0-9]+\z/, record2.slug)
+      record2 = model_class.create! name: "Peugeot 206"
+      assert_match(/\Apeugeot-206-([a-z0-9]+-){4}[a-z0-9]+\z/, record2.slug)
     end
   end
 
   test "should correctly sequence slugs with underscores" do
     transaction do
-      Novelist.create! :name => 'wordsfail, buildings tumble'
-      record2 = Novelist.create! :name => 'word fail'
-      assert_equal 'word_fail', record2.slug
+      Novelist.create! name: "wordsfail, buildings tumble"
+      record2 = Novelist.create! name: "word fail"
+      assert_equal "word_fail", record2.slug
     end
   end
 
   test "should correctly sequence numeric slugs" do
     transaction do
-      n2 = 2.times.map {Article.create :name => '123'}.last
+      n2 = 2.times.map { Article.create name: "123" }.last
       assert_match(/\A123-.*/, n2.friendly_id)
     end
   end
-
 end
 
 class SlugSeparatorTest < TestCaseClass
-
   include FriendlyId::Test
 
   class Journalist < ActiveRecord::Base
     extend FriendlyId
-    friendly_id :name, :use => :slugged, :sequence_separator => ":"
+    friendly_id :name, use: :slugged, sequence_separator: ":"
   end
 
   def model_class
@@ -294,7 +290,7 @@ class SlugSeparatorTest < TestCaseClass
 
   test "should sequence with configured sequence separator" do
     with_instance_of model_class do |record|
-      record2 = model_class.create! :name => record.name
+      record2 = model_class.create! name: record.name
       assert record2.friendly_id.match(/:.*\z/)
     end
   end
@@ -310,34 +306,32 @@ class SlugSeparatorTest < TestCaseClass
     model_class = Class.new(ActiveRecord::Base) do
       self.table_name = "journalists"
       extend FriendlyId
-      friendly_id :name, :use => :slugged, :sequence_separator => '-'
+      friendly_id :name, use: :slugged, sequence_separator: "-"
       def self.name
         "Journalist"
       end
     end
     transaction do
-      record1 = model_class.create! :name => "Peugeot 206"
+      record1 = model_class.create! name: "Peugeot 206"
       assert_equal "peugeot-206", record1.slug
-      record2 = model_class.create! :name => "Peugeot 206"
-      assert_match(/\Apeugeot-206-([a-z0-9]+\-){4}[a-z0-9]+\z/, record2.slug)
+      record2 = model_class.create! name: "Peugeot 206"
+      assert_match(/\Apeugeot-206-([a-z0-9]+-){4}[a-z0-9]+\z/, record2.slug)
     end
   end
 
   test "should sequence blank slugs without a separator" do
-    with_instance_of model_class, :name => "" do |record|
-      assert_match(/\A([a-z0-9]+\-){4}[a-z0-9]+\z/, record.slug)
+    with_instance_of model_class, name: "" do |record|
+      assert_match(/\A([a-z0-9]+-){4}[a-z0-9]+\z/, record.slug)
     end
   end
-
 end
 
 class SlugLimitTest < TestCaseClass
-
   include FriendlyId::Test
 
   class Journalist < ActiveRecord::Base
     extend FriendlyId
-    friendly_id :name, :use => :slugged, :slug_limit => 40
+    friendly_id :name, use: :slugged, slug_limit: 40
   end
 
   def model_class
@@ -346,48 +340,45 @@ class SlugLimitTest < TestCaseClass
 
   test "should limit slug size" do
     transaction do
-      m1 = model_class.create! :name => 'a' * 50
-      assert_equal m1.slug, 'a' * 40
-      m2 = model_class.create! :name => m1.name
+      m1 = model_class.create! name: "a" * 50
+      assert_equal m1.slug, "a" * 40
+      m2 = model_class.create! name: m1.name
       m2.save!
       # "aaa-<uid>"
-      assert_match(/\Aa{3}\-/, m2.slug)
+      assert_match(/\Aa{3}-/, m2.slug)
     end
   end
 end
 
 class DefaultScopeTest < TestCaseClass
-
   include FriendlyId::Test
 
   class Journalist < ActiveRecord::Base
     extend FriendlyId
-    friendly_id :name, :use => :slugged
-    default_scope -> { where(:active => true).order('id ASC') }
+    friendly_id :name, use: :slugged
+    default_scope -> { where(active: true).order("id ASC") }
   end
 
   test "friendly_id should correctly sequence a default_scoped ordered table" do
     transaction do
-      3.times { assert Journalist.create :name => "a", :active => true }
+      3.times { assert Journalist.create name: "a", active: true }
     end
   end
 
   test "friendly_id should correctly sequence a default_scoped scoped table" do
     transaction do
-      assert Journalist.create :name => "a", :active => false
-      assert Journalist.create :name => "a", :active => true
+      assert Journalist.create name: "a", active: false
+      assert Journalist.create name: "a", active: true
     end
   end
-
 end
 
 class UuidAsPrimaryKeyFindTest < TestCaseClass
-
   include FriendlyId::Test
 
   class MenuItem < ActiveRecord::Base
     extend FriendlyId
-    friendly_id :name, :use => :slugged
+    friendly_id :name, use: :slugged
     before_create :init_primary_key
 
     def self.primary_key
@@ -400,6 +391,7 @@ class UuidAsPrimaryKeyFindTest < TestCaseClass
     end
 
     private
+
     def init_primary_key
       self.uuid_key = SecureRandom.uuid
     end
@@ -427,46 +419,40 @@ class UuidAsPrimaryKeyFindTest < TestCaseClass
       end
     end
   end
-
 end
 
 class UnderscoreAsSequenceSeparatorRegressionTest < TestCaseClass
-
   include FriendlyId::Test
 
   class Manual < ActiveRecord::Base
     extend FriendlyId
-    friendly_id :name, :use => :slugged, :sequence_separator => "_"
+    friendly_id :name, use: :slugged, sequence_separator: "_"
   end
 
   test "should not create duplicate slugs" do
     3.times do
       transaction do
-        begin
-          assert Manual.create! :name => "foo"
-        rescue
-          flunk "Tried to insert duplicate slug"
-        end
+        assert Manual.create! name: "foo"
+      rescue
+        flunk "Tried to insert duplicate slug"
       end
     end
   end
-
 end
 
 # https://github.com/norman/friendly_id/issues/148
 class FailedValidationAfterUpdateRegressionTest < TestCaseClass
-
   include FriendlyId::Test
 
   class Journalist < ActiveRecord::Base
     extend FriendlyId
-    friendly_id :name, :use => :slugged
+    friendly_id :name, use: :slugged
     validates_presence_of :slug_de
   end
 
   test "to_param should return the unchanged value if the slug changes before validation fails" do
     transaction do
-      journalist = Journalist.create! :name => "Joseph Pulitzer", :slug_de => "value"
+      journalist = Journalist.create! name: "Joseph Pulitzer", slug_de: "value"
       assert_equal "joseph-pulitzer", journalist.to_param
       assert journalist.valid?
       assert journalist.persisted?
@@ -476,49 +462,45 @@ class FailedValidationAfterUpdateRegressionTest < TestCaseClass
       assert_equal "joseph-pulitzer", journalist.to_param
     end
   end
-
 end
 
 # https://github.com/norman/friendly_id/issues/947
 class GeneratingSlugWithValidationSkippedTest < TestCaseClass
-
   include FriendlyId::Test
 
   class Journalist < ActiveRecord::Base
     extend FriendlyId
-    friendly_id :name, :use => :slugged
+    friendly_id :name, use: :slugged
   end
 
   test "should generate slug when skipping validation" do
     transaction do
       m1 = Journalist.new
-      m1.name = 'Bob Timesletter'
+      m1.name = "Bob Timesletter"
       m1.save(validate: false)
-      assert_equal 'bob-timesletter', m1.slug
+      assert_equal "bob-timesletter", m1.slug
     end
   end
 
   test "should generate slug when #valid? called" do
     transaction do
       m1 = Journalist.new
-      m1.name = 'Bob Timesletter'
+      m1.name = "Bob Timesletter"
       m1.valid?
       m1.save(validate: false)
-      assert_equal 'bob-timesletter', m1.slug
+      assert_equal "bob-timesletter", m1.slug
     end
   end
-
 end
 
 class ToParamTest < TestCaseClass
-
   include FriendlyId::Test
 
   class Journalist < ActiveRecord::Base
     extend FriendlyId
     validates_presence_of :active
-    validates_length_of :slug, :minimum => 2
-    friendly_id :name, :use => :slugged
+    validates_length_of :slug, minimum: 2
+    friendly_id :name, use: :slugged
 
     attr_accessor :to_param_in_callback
 
@@ -532,86 +514,85 @@ class ToParamTest < TestCaseClass
   end
 
   test "to_param should return original slug if record failed validation" do
-    journalist = Journalist.new :name => 'Clark Kent', :active => nil
+    journalist = Journalist.new name: "Clark Kent", active: nil
     refute journalist.save
-    assert_equal 'clark-kent', journalist.to_param
+    assert_equal "clark-kent", journalist.to_param
   end
 
   test "to_param should clear slug attributes if slug attribute fails validation" do
-    journalist = Journalist.new :name => 'x', :active => true
+    journalist = Journalist.new name: "x", active: true
     refute journalist.save
     assert_nil journalist.to_param
   end
 
   test "to_param should clear slug attribute if slug attribute fails validation and unrelated validation fails" do
-    journalist = Journalist.new :name => 'x', :active => nil
+    journalist = Journalist.new name: "x", active: nil
     refute journalist.save
     assert_nil journalist.to_param
   end
 
   test "to_param should use slugged attribute if record saved successfully" do
     transaction do
-      journalist = Journalist.new :name => 'Clark Kent', :active => true
+      journalist = Journalist.new name: "Clark Kent", active: true
       assert journalist.save
-      assert_equal 'clark-kent', journalist.to_param
+      assert_equal "clark-kent", journalist.to_param
     end
   end
 
   test "to_param should use new slug if existing record changes but fails to save" do
     transaction do
-      journalist = Journalist.new :name => 'Clark Kent', :active => true
+      journalist = Journalist.new name: "Clark Kent", active: true
       assert journalist.save
-      journalist.name = 'Superman'
+      journalist.name = "Superman"
       journalist.slug = nil
       journalist.active = nil
       refute journalist.save
-      assert_equal 'superman', journalist.to_param
+      assert_equal "superman", journalist.to_param
     end
   end
 
   test "to_param should use original slug if new slug attribute is not valid" do
     transaction do
-      journalist = Journalist.new :name => 'Clark Kent', :active => true
+      journalist = Journalist.new name: "Clark Kent", active: true
       assert journalist.save
-      journalist.name = 'x'
+      journalist.name = "x"
       journalist.slug = nil
       journalist.active = nil
       refute journalist.save
-      assert_equal 'clark-kent', journalist.to_param
+      assert_equal "clark-kent", journalist.to_param
     end
   end
 
   test "to_param should use new slug if existing record changes successfully" do
     transaction do
-      journalist = Journalist.new :name => 'Clark Kent', :active => true
+      journalist = Journalist.new name: "Clark Kent", active: true
       assert journalist.save
-      journalist.name = 'Superman'
+      journalist.name = "Superman"
       journalist.slug = nil
       assert journalist.save
-      assert_equal 'superman', journalist.to_param
+      assert_equal "superman", journalist.to_param
     end
   end
 
   test "to_param should use new slug within callbacks if new record is saved successfully" do
     transaction do
-      journalist = Journalist.new :name => 'Clark Kent', :active => true
+      journalist = Journalist.new name: "Clark Kent", active: true
       assert journalist.save
-      assert_equal 'clark-kent', journalist.to_param_in_callback, "value of to_param in callback should use the new slug value"
+      assert_equal "clark-kent", journalist.to_param_in_callback, "value of to_param in callback should use the new slug value"
     end
   end
 
   test "to_param should use new slug within callbacks if existing record changes successfully" do
     transaction do
-      journalist = Journalist.new :name => 'Clark Kent', :active => true
+      journalist = Journalist.new name: "Clark Kent", active: true
       assert journalist.save
       assert journalist.valid?
-      journalist.name = 'Superman'
+      journalist.name = "Superman"
       journalist.slug = nil
       assert journalist.save, "save should be successful"
-      assert_equal 'superman', journalist.to_param_in_callback, "value of to_param in callback should use the new slug value"
+      assert_equal "superman", journalist.to_param_in_callback, "value of to_param in callback should use the new slug value"
     end
   end
-
 end
 
 class ConfigurableRoutesTest < TestCaseClass
@@ -620,18 +601,18 @@ class ConfigurableRoutesTest < TestCaseClass
   class Article < ActiveRecord::Base
     extend FriendlyId
 
-    friendly_id :name, :use => :slugged, :routes => :friendly
+    friendly_id :name, use: :slugged, routes: :friendly
   end
 
   class Novel < ActiveRecord::Base
     extend FriendlyId
 
-    friendly_id :name, :use => :slugged, :routes => :default
+    friendly_id :name, use: :slugged, routes: :default
   end
 
   test "to_param should return a friendly id when the routes option is set to :friendly" do
     transaction do
-      article = Article.create! :name => "Titanic Hits; Iceberg Sinks"
+      article = Article.create! name: "Titanic Hits; Iceberg Sinks"
 
       assert_equal "titanic-hits-iceberg-sinks", article.to_param
     end
@@ -639,7 +620,7 @@ class ConfigurableRoutesTest < TestCaseClass
 
   test "to_param should return the id when the routes option is set to anything but friendly" do
     transaction do
-      novel = Novel.create! :name => "Don Quixote"
+      novel = Novel.create! name: "Don Quixote"
 
       assert_equal novel.id.to_s, novel.to_param
     end

--- a/test/sti_test.rb
+++ b/test/sti_test.rb
@@ -1,14 +1,13 @@
 require "helper"
 
 class StiTest < TestCaseClass
-
   include FriendlyId::Test
   include FriendlyId::Test::Shared::Core
   include FriendlyId::Test::Shared::Slugged
 
   class Journalist < ActiveRecord::Base
     extend FriendlyId
-    friendly_id :name, :use => [:slugged]
+    friendly_id :name, use: [:slugged]
   end
 
   class Editorialist < Journalist
@@ -20,9 +19,11 @@ class StiTest < TestCaseClass
 
   test "friendly_id should accept a base and a hash with single table inheritance" do
     abstract_klass = Class.new(ActiveRecord::Base) do
-      def self.table_exists?; false end
+      def self.table_exists?
+        false
+      end
       extend FriendlyId
-      friendly_id :foo, :use => :slugged, :slug_column => :bar
+      friendly_id :foo, use: :slugged, slug_column: :bar
     end
     klass = Class.new(abstract_klass)
     assert klass < FriendlyId::Slugged
@@ -36,7 +37,9 @@ class StiTest < TestCaseClass
 
   test "friendly_id should accept a block with single table inheritance" do
     abstract_klass = Class.new(ActiveRecord::Base) do
-      def self.table_exists?; false end
+      def self.table_exists?
+        false
+      end
       extend FriendlyId
       friendly_id :foo do |config|
         config.use :slugged
@@ -52,10 +55,10 @@ class StiTest < TestCaseClass
 
   test "friendly_id slugs should not clash with each other" do
     transaction do
-      journalist  = model_class.base_class.create! :name => 'foo bar'
-      editoralist = model_class.create! :name => 'foo bar'
+      journalist = model_class.base_class.create! name: "foo bar"
+      editoralist = model_class.create! name: "foo bar"
 
-      assert_equal 'foo-bar', journalist.slug
+      assert_equal "foo-bar", journalist.slug
       assert_match(/foo-bar-.+/, editoralist.slug)
     end
   end
@@ -64,7 +67,7 @@ end
 class StiTestWithHistory < StiTest
   class Journalist < ActiveRecord::Base
     extend FriendlyId
-    friendly_id :name, :use => [:slugged, :history]
+    friendly_id :name, use: [:slugged, :history]
   end
 
   class Editorialist < Journalist
@@ -75,19 +78,17 @@ class StiTestWithHistory < StiTest
   end
 end
 
-
 class StiTestWithFinders < TestCaseClass
-
   include FriendlyId::Test
 
   class Journalist < ActiveRecord::Base
     extend FriendlyId
-    friendly_id :name, :use => [:slugged, :finders]
+    friendly_id :name, use: [:slugged, :finders]
   end
 
   class Editorialist < Journalist
     extend FriendlyId
-    friendly_id :name, :use => [:slugged, :finders]
+    friendly_id :name, use: [:slugged, :finders]
   end
 
   def model_class
@@ -96,22 +97,20 @@ class StiTestWithFinders < TestCaseClass
 
   test "friendly_id slugs should be looked up from subclass with friendly" do
     transaction do
-      editoralist = model_class.create! :name => 'foo bar'
+      editoralist = model_class.create! name: "foo bar"
       assert_equal editoralist, model_class.friendly.find(editoralist.slug)
     end
   end
 
   test "friendly_id slugs should be looked up from subclass" do
     transaction do
-      editoralist = model_class.create! :name => 'foo bar'
+      editoralist = model_class.create! name: "foo bar"
       assert_equal editoralist, model_class.find(editoralist.slug)
     end
   end
-
 end
 
 class StiTestSubClass < TestCaseClass
-
   include FriendlyId::Test
 
   class Journalist < ActiveRecord::Base
@@ -120,7 +119,7 @@ class StiTestSubClass < TestCaseClass
 
   class Editorialist < Journalist
     extend FriendlyId
-    friendly_id :name, :use => [:slugged, :finders]
+    friendly_id :name, use: [:slugged, :finders]
   end
 
   def model_class
@@ -129,9 +128,8 @@ class StiTestSubClass < TestCaseClass
 
   test "friendly_id slugs can be created and looked up from subclass" do
     transaction do
-      editoralist = model_class.create! :name => 'foo bar'
+      editoralist = model_class.create! name: "foo bar"
       assert_equal editoralist, model_class.find(editoralist.slug)
     end
   end
-
 end


### PR DESCRIPTION
To get the codebase into a consistent state, I've formatted it using the
[standard](https://github.com/testdouble/standard) gem.

This lets us get on with writing code without spending any time deciding
how it should look.