### PR TITLE
Add Rails 7 to CI matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,11 +10,15 @@ jobs:
     strategy:
       matrix:
         database: [ mysql, postgresql ]
-        gemfile: [ '6.1', '6.0', '5.2' ]
+        gemfile: [ '7.0', '6.1', '6.0', '5.2' ]
         ruby: [ '2.5', '2.6', '2.7', '3.0' ]
         exclude:
           - ruby: '3.0'
             gemfile: '5.2'
+          - ruby: '2.5'
+            gemfile: '7.0'
+          - ruby: '2.6'
+            gemfile: '7.0'
       fail-fast: false
     runs-on: ubuntu-latest
 

--- a/gemfiles/Gemfile.rails-7.0.rb
+++ b/gemfiles/Gemfile.rails-7.0.rb
@@ -1,0 +1,22 @@
+source "https://rubygems.org"
+
+gemspec path: "../"
+
+gem "activerecord", "~> 7.0.0"
+gem "railties", "~> 7.0.0"
+
+# Database Configuration
+group :development, :test do
+  platforms :jruby do
+    gem "activerecord-jdbcmysql-adapter", "~> 61.0"
+    gem "activerecord-jdbcpostgresql-adapter", "~> 61.0"
+    gem "kramdown"
+  end
+
+  platforms :ruby, :rbx do
+    gem "sqlite3"
+    gem "mysql2"
+    gem "pg"
+    gem "redcarpet"
+  end
+end


### PR DESCRIPTION
Rails 7.0 was released. This PR adds it to the CI Matrix, excluding Ruby 2.5 and 2.6 because the minimum version of Ruby required for Rails 7 is 2.7.