### PR TITLE
Drop support for Ruby 2.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,13 +10,11 @@ jobs:
     strategy:
       matrix:
         database: [ mysql, postgresql ]
-        gemfile: [ '7.0', '6.1', '6.0', '5.2' ]
-        ruby: [ '2.5', '2.6', '2.7', '3.0' ]
+        gemfile: [ '7.0', '6.1', '6.0' ]
+        ruby: [ '2.6', '2.7', '3.0' ]
         exclude:
           - ruby: '3.0'
             gemfile: '5.2'
-          - ruby: '2.5'
-            gemfile: '7.0'
           - ruby: '2.6'
             gemfile: '7.0'
       fail-fast: false

--- a/friendly_id.gemspec
+++ b/friendly_id.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.license = "MIT"
 
-  s.required_ruby_version = ">= 2.1.0"
+  s.required_ruby_version = ">= 2.6.0"
 
   s.add_dependency "activerecord", ">= 4.0.0"
 

--- a/friendly_id.gemspec
+++ b/friendly_id.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.license = "MIT"
 
-  s.required_ruby_version = ">= 2.6.0"
+  s.required_ruby_version = ">= 2.1.0"
 
   s.add_dependency "activerecord", ">= 4.0.0"
 


### PR DESCRIPTION
Ruby 2.5 arrived to EOL. I think it is the moment to drop the support.