### PR TITLE
Add Ruby 3.1 to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,8 +13,6 @@ jobs:
         gemfile: [ '7.0', '6.1', '6.0' ]
         ruby: [ '2.6', '2.7', '3.0', '3.1' ]
         exclude:
-          - ruby: '3.1'
-            gemfile: '6.0'
           - ruby: '2.6'
             gemfile: '7.0'
       fail-fast: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,10 +11,10 @@ jobs:
       matrix:
         database: [ mysql, postgresql ]
         gemfile: [ '7.0', '6.1', '6.0' ]
-        ruby: [ '2.6', '2.7', '3.0' ]
+        ruby: [ '2.6', '2.7', '3.0', '3.1' ]
         exclude:
-          - ruby: '3.0'
-            gemfile: '5.2'
+          - ruby: '3.1'
+            gemfile: '6.0'
           - ruby: '2.6'
             gemfile: '7.0'
       fail-fast: false


### PR DESCRIPTION
This PR adds Ruby 3.1 to CI.

It also cleans up an unnecessary exclusion for Ruby 3.0 / Rails 5.2 (Rails 5.2 was already removed from the CI matrix).