### PR TITLE
Fix collision errors when introducing history plugin after the fact

### DIFF
--- a/lib/friendly_id/history.rb
+++ b/lib/friendly_id/history.rb
@@ -106,7 +106,7 @@ module FriendlyId
     # to be conflicts. This will allow a record to revert to a previously
     # used slug.
     def scope_for_slug_generator
-      relation = super.joins(:slugs)
+      relation = super.includes(:slugs)
       unless new_record?
         relation = relation.merge(Slug.where("sluggable_id <> ?", id))
       end

--- a/lib/friendly_id/history.rb
+++ b/lib/friendly_id/history.rb
@@ -102,18 +102,14 @@ module FriendlyId
 
     private
 
-    # If we're updating, don't consider historic slugs for the same record
-    # to be conflicts. This will allow a record to revert to a previously
-    # used slug.
     def scope_for_slug_generator
-      relation = super.includes(:slugs)
-      unless new_record?
-        relation = relation.merge(Slug.where("sluggable_id <> ?", id))
-      end
+      relation = super.left_joins(:slugs)
+
       if friendly_id_config.uses?(:scoped)
-        relation = relation.where(Slug.arel_table[:scope].eq(serialized_scope))
+        relation.where(Slug.arel_table[:scope].eq(serialized_scope))
+      else
+        relation
       end
-      relation
     end
 
     def create_slug

--- a/test/candidates_test.rb
+++ b/test/candidates_test.rb
@@ -139,4 +139,28 @@ class CandidatesTest < TestCaseClass
       assert_equal collected_candidates, ["new-york"]
     end
   end
+
+  test "should not fail when adding history to existing" do
+    name_collision = "Amsterdam"
+
+    with_instances do |city1, _|
+      assert city1.update name: name_collision, slug: nil
+      assert_equal name_collision.downcase, city1.slug
+
+      klass = Class.new city1.class do
+        friendly_id_config.model_class = city1.class
+        friendly_id_config.use(:history)
+
+        def slug_candidates
+          [:name, [:name, "-alt"]]
+        end
+      end
+      assert klass.friendly_id_config.uses? :history
+
+      city2 = klass.last
+
+      assert city2.update name: name_collision, slug: nil
+      assert_equal "#{name_collision.downcase}-alt", city2.slug
+    end
+  end
 end

--- a/test/history_test.rb
+++ b/test/history_test.rb
@@ -83,12 +83,15 @@ class HistoryTest < TestCaseClass
       record.name = "x"
       record.slug = nil
       assert record.save
+      assert record.slug == "x"
       record.name = "y"
       record.slug = nil
       assert record.save
+      assert record.slug == "y"
       record.name = "x"
       record.slug = nil
       assert record.save
+      assert record.slug == "x"
     end
   end
 

--- a/test/history_test.rb
+++ b/test/history_test.rb
@@ -114,6 +114,20 @@ class HistoryTest < TestCaseClass
     end
   end
 
+  test "should not get an old slug used by another" do
+    transaction do
+      record = model_class.create! :name => "Old Name"
+      assert_equal record.slug, "old-name"
+      record.update :name => "New Name", :slug => nil
+      assert_equal record.slug, "new-name"
+
+      new_record = model_class.create! :name => "Old Name"
+      assert_match(/old-name(-\w+){5}/, new_record.slug)
+
+      assert_equal model_class.friendly.find("old-name"), record
+    end
+  end
+
   test "should not create new slugs that match old slugs" do
     transaction do
       first_record = model_class.create! name: "foo"
@@ -429,6 +443,53 @@ class ScopedHistoryTest < TestCaseClass
       second_record = model_class.create! city: second_city, name: "x"
 
       assert_equal record.slug, second_record.slug
+    end
+  end
+end
+
+class MigrationTest < TestCaseClass
+  include FriendlyId::Test
+
+  class City < ActiveRecord::Base
+    extend FriendlyId
+    friendly_id :slug_candidates, use: :slugged
+    alias_attribute :slug_candidates, :name
+  end
+
+  def with_migrate_scenario(city_name = "New York", &block)
+    transaction do
+      city = City.create! name: city_name
+
+      klass = Class.new City do
+        friendly_id_config.model_class = City
+        friendly_id_config.use(:history)
+
+        def slug_candidates
+          [:name, [:name, "-alt"]]
+        end
+      end
+
+      yield city, klass
+    end
+  end
+
+  test "should not fail when adding history to existing" do
+    name_collision = "Amsterdam"
+
+    with_migrate_scenario(name_collision) do |city, klass|
+      city2 = klass.create! name: "New York"
+
+      assert city2.update name: name_collision, slug: nil
+      assert_equal "#{name_collision.downcase}-alt", city2.slug
+    end
+  end
+
+  test "scope_for_slug_generator should find slugs not in Slug table" do
+    with_migrate_scenario do |city, klass|
+      assert klass.new.send(:scope_for_slug_generator).include? city
+
+      city2 = klass.create! name: city.name
+      assert city2.send(:scope_for_slug_generator).include? city
     end
   end
 end


### PR DESCRIPTION
I've redone the work of #850 

The problem that still exists in this current version is:
1. implement the friendly_id slugs
2. figuring out somewhere along the line that you want the history plugin as well
3. create a new sluggable record that would translate to an already existing slug
4. fails with a database constraint on unique slugs

The method 'scope_for_slug_generator' did a bit too much work with an inner join that made existing records with no entry in the history table being filtered out.