### PR TITLE
fix for UUID set on invalid object

### DIFF
--- a/lib/friendly_id/slugged.rb
+++ b/lib/friendly_id/slugged.rb
@@ -372,9 +372,13 @@ module FriendlyId
     private :slug_generator
 
     def unset_slug_if_invalid
-      if errors.key?(friendly_id_config.query_field) && attribute_changed?(friendly_id_config.query_field.to_s)
-        diff = changes[friendly_id_config.query_field]
-        send "#{friendly_id_config.slug_column}=", diff.first
+      if (
+        errors.key?(friendly_id_config.base) ||
+        errors.key?(friendly_id_config.query_field) # slug_column
+      ) && attribute_changed?(friendly_id_config.query_field)
+
+        prior_slug = changes[friendly_id_config.query_field]&.first
+        send "#{friendly_id_config.query_field}=", prior_slug
       end
     end
     private :unset_slug_if_invalid

--- a/test/slugged_test.rb
+++ b/test/slugged_test.rb
@@ -42,6 +42,22 @@ class SluggedTest < TestCaseClass
     refute instance.valid?
   end
 
+  test "should allow validations on the base" do
+    model_class = Class.new(ActiveRecord::Base) do
+      self.table_name = "articles"
+      extend FriendlyId
+      friendly_id :name, use: :slugged
+      validates :name, presence: true
+    end
+    instance = model_class.new name: ""
+    refute instance.valid? # run Slugged validation hooks
+
+    # setting slug to UUID, e.g. "2d28c5c1-4eee-49ef-aee8-4842fddbe895",
+    # at this point is a problem.  This will be sent back to Rails form_with
+    # and inserted into the form action= url value.
+    assert(instance.slug.nil?)
+  end
+
   test "should allow nil slugs" do
     transaction do
       m1 = model_class.create!


### PR DESCRIPTION
Bug:
  When using `:should_generate_new_friendly_id?` to enable slug update functionality,
  on a model which has option `friendly_id :title, use: :slugged`, and an existing
  `validates :title, presence: true`, the UUID is being set as the slug while the
  object is in an invalid state.  In a rails app, this will be set as the action
  attribute in a `form_with` form, causing errors.

Fix:
  Add an `errors.key?(friendly_id_config.base)` guard clause to `:unset_slug_if_invalid`
  callback method.