### PR TITLE
Upgrade Mocha in development dependencies

### DIFF
--- a/friendly_id.gemspec
+++ b/friendly_id.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "coveralls"
   s.add_development_dependency "railties", ">= 4.0"
   s.add_development_dependency "minitest", "~> 5.3"
-  s.add_development_dependency "mocha", "~> 1.1"
+  s.add_development_dependency "mocha", "~> 2.1"
   s.add_development_dependency "yard"
   s.add_development_dependency "i18n"
   s.add_development_dependency "ffaker"

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -19,9 +19,9 @@ rescue LoadError
 end
 
 begin
-  TestCaseClass = MiniTest::Test
+  TestCaseClass = Minitest::Test
 rescue NameError
-  TestCaseClass = MiniTest::Unit::TestCase
+  TestCaseClass = Minitest::Unit::TestCase
 end
 
 require "mocha/minitest"


### PR DESCRIPTION
Currently CI is failing because we refer to `MiniTest` and the class is
`Minitest`. This is also something that Mocha is doing, which is one of
our development dependencies, but updating that fixes it.