### PR TITLE
Add Rails 7.1 to CI Matrix and drop support for Ruby 2.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,11 +10,9 @@ jobs:
     strategy:
       matrix:
         database: [ mysql, postgresql ]
-        gemfile: [ '7.0', '6.1', '6.0' ]
-        ruby: [ '2.6', '2.7', '3.0', '3.1', '3.2' ]
+        gemfile: [ '7.1', '7.0', '6.1', '6.0' ]
+        ruby: [ '2.7', '3.0', '3.1', '3.2' ]
         exclude:
-          - ruby: '2.6'
-            gemfile: '7.0'
           - ruby: '3.2'
             gemfile: '6.0'
           - ruby: '3.2'

--- a/gemfiles/Gemfile.rails-7.1.rb
+++ b/gemfiles/Gemfile.rails-7.1.rb
@@ -2,14 +2,14 @@ source "https://rubygems.org"
 
 gemspec path: "../"
 
-gem "activerecord", "~> 5.2.0"
-gem "railties", "~> 5.2.0"
+gem "activerecord", "~> 7.1.0"
+gem "railties", "~> 7.1.0"
 
 # Database Configuration
 group :development, :test do
   platforms :jruby do
-    gem "activerecord-jdbcmysql-adapter", "~> 51.1"
-    gem "activerecord-jdbcpostgresql-adapter", "~> 51.1"
+    gem "activerecord-jdbcmysql-adapter", "~> 61.0"
+    gem "activerecord-jdbcpostgresql-adapter", "~> 61.0"
     gem "kramdown"
   end
 


### PR DESCRIPTION
This PR does three things:

- Add Rails 7.1 to the matrix
- Drops support for Ruby 2.6 (almost 2 years EOL)
- Removes Gemfile for Rails 5.2 (well, in the code diff looks like renamed and modified because I've added the Gemfile for Rails 7.1)