### PR TITLE
Fix up transliteration documentation.

### DIFF
--- a/lib/friendly_id/base.rb
+++ b/lib/friendly_id/base.rb
@@ -150,7 +150,7 @@ module FriendlyId
     #       config.use :slugged
     #       config.use Module.new {
     #         def normalize_friendly_id(text)
-    #           text.to_slug.normalize! :transliterations => [:russian, :latin]
+    #           text.to_slug.normalize! :transliterate => [:russian, :latin]
     #         end
     #       }
     #     end

--- a/lib/friendly_id/initializer.rb
+++ b/lib/friendly_id/initializer.rb
@@ -101,7 +101,7 @@ FriendlyId.defaults do |config|
   #
   # config.use Module.new {
   #   def normalize_friendly_id(text)
-  #     text.to_slug.normalize! :transliterations => [:russian, :latin]
+  #     text.to_slug.normalize! :transliterate => [:russian, :latin]
   #   end
   # }
 end


### PR DESCRIPTION
The current documentation for transliteration does not transliterate.

```ruby
> "для Минималистов".to_slug.normalize!(:transliterations => [:russian, :latin]).to_s
=> "для-минималистов"
```

These two commands do successfully transliterate, so let's update the documentation to the simplest of the two:

```ruby
> "для Минималистов".to_slug.normalize!(:transliterate => [:russian, :latin]).to_s
=> "dlya-minimalistov"
> "для Минималистов".to_slug.normalize(:transliterate => true, :transliterations => [:russian, :latin]).to_s
=> "dlya-minimalistov"
```