### PR TITLE
Add dependent option to initializer

### DIFF
--- a/lib/friendly_id/history.rb
+++ b/lib/friendly_id/history.rb
@@ -50,6 +50,13 @@ module FriendlyId
   #         end
   #       end
   #     end
+  #     
+  # ### Dependent
+  # 
+  # This module adds a polymorphic `has_many :slugs, ...` association to the model class.
+  # By default slugs will be destroyed when the record is destroyed.
+  # You can change this behavior with the `dependent` configuration option in
+  # `initializers/friendly_id.rb`.
   #
   # @guide end
   module History

--- a/lib/friendly_id/initializer.rb
+++ b/lib/friendly_id/initializer.rb
@@ -104,4 +104,16 @@ FriendlyId.defaults do |config|
   #     text.to_slug.normalize! :transliterations => [:russian, :latin]
   #   end
   # }
+  # 
+  # FriendlyId's history module adds a polymorphic `has_many :slugs, ...` association
+  # to the model. By default slugs will be destroyed when the record is destroyed.
+  # 
+  # To disable this use `false`. Other options include:
+  # - :delete
+  # - :destroy_async
+  # - :nullify
+  # - :restrict_with_exception
+  # - :restrict_with_error
+  # 
+  # config.dependent :destroy
 end


### PR DESCRIPTION
This just adds the existing `dependent` option for the history module to the initializer file and the guide for the History module.

Did I mess a step for building the Yarddoc is is that done automatically?