### PR TITLE
enhancement: array finders

### DIFF
--- a/lib/friendly_id/finder_methods.rb
+++ b/lib/friendly_id/finder_methods.rb
@@ -1,3 +1,5 @@
+require "set"
+
 module FriendlyId
   module FinderMethods
     # Finds a record using the given id.
@@ -27,6 +29,12 @@ module FriendlyId
     # @raise ActiveRecord::RecordNotFound
     def find(*args, allow_nil: false)
       id = args.first
+      
+      # Handle array of IDs (potentially including slugs)
+      if args.count == 1 && id.is_a?(Array)
+        return find_by_array(id, allow_nil: allow_nil)
+      end
+      
       return super(*args) if args.count != 1 || id.unfriendly_id?
       first_by_friendly_id(id).tap { |result| return result unless result.nil? }
       return super(*args) if potential_primary_key?(id)
@@ -48,6 +56,80 @@ module FriendlyId
     # @raise ActiveRecord::RecordNotFound
     def find_by_friendly_id(id)
       first_by_friendly_id(id) or raise_not_found_exception(id)
+    end
+
+    # Finds records by an array of IDs, which may include friendly IDs (slugs)
+    # and/or numeric primary keys.
+    # @raise ActiveRecord::RecordNotFound
+    def find_by_array(ids, allow_nil: false)
+      return [] if ids.empty?
+      
+      # Separate potential slugs from numeric IDs
+      slugs = []
+      numeric_ids = []
+      
+      ids.each do |id|
+        if id.unfriendly_id? || potential_primary_key?(id)
+          numeric_ids << id
+        else
+          slugs << id
+        end
+      end
+      
+      # Find records by slugs
+      records_by_slugs = []
+      if slugs.any?
+        # Parse slugs and find by friendly_id field
+        parsed_slugs = slugs.map { |slug| parse_friendly_id(slug) }
+        records_by_slugs = where(friendly_id_config.query_field => parsed_slugs).to_a
+      end
+      
+      # Find records by numeric IDs using original ActiveRecord find
+      records_by_ids = []
+      if numeric_ids.any?
+        begin
+          # Use where with primary key to find by numeric IDs, which avoids
+          # calling the overridden find method and works like the original
+          primary_key_name = self.primary_key
+          records_by_ids = where(primary_key_name => numeric_ids).to_a
+          
+          # Check if we found all requested numeric IDs
+          found_ids = records_by_ids.map(&:id)
+          missing_ids = numeric_ids - found_ids
+          if missing_ids.any? && !allow_nil
+            # Use the same error format as ActiveRecord for missing IDs
+            if ActiveRecord.version < Gem::Version.create("5.0")
+              raise ActiveRecord::RecordNotFound.new("Couldn't find #{self.name} with 'id'=#{missing_ids.first}")
+            else
+              raise ActiveRecord::RecordNotFound.new("Couldn't find #{self.name} with 'id'=#{missing_ids.first}", self.name, :id, missing_ids.first)
+            end
+          end
+        rescue ActiveRecord::RecordNotFound => e
+          # If allow_nil is true, we continue and return partial results
+          # If allow_nil is false, we re-raise the exception
+          raise e unless allow_nil
+        end
+      end
+      
+      # Combine results
+      all_records = records_by_slugs + Array(records_by_ids)
+      
+      # Check if we found all requested slugs (numeric IDs are already checked above)
+      unless allow_nil
+        if slugs.any?
+          found_slugs = Set.new(records_by_slugs.map { |record| record.send(friendly_id_config.query_field) })
+          parsed_slugs = slugs.map { |slug| parse_friendly_id(slug) }
+          missing_slugs = parsed_slugs - found_slugs.to_a
+          
+          if missing_slugs.any?
+            # Find the original slug that corresponds to the missing parsed slug
+            original_missing_slug = slugs.find { |slug| parse_friendly_id(slug) == missing_slugs.first }
+            raise_not_found_exception(original_missing_slug)
+          end
+        end
+      end
+      
+      all_records
     end
 
     def exists_by_friendly_id?(id)

--- a/test/finders_test.rb
+++ b/test/finders_test.rb
@@ -73,4 +73,133 @@ class Finders < TestCaseClass
       assert_nil model_class.existing.find(nil, allow_nil: true)
     end
   end
+
+  # Array finder tests
+  test "should find records by array of slugs" do
+    with_instances_of(model_class, 2) do |record1, record2|
+      slugs = [record1.friendly_id, record2.friendly_id]
+      found_records = model_class.find(slugs)
+      
+      assert_equal 2, found_records.size
+      assert_includes found_records, record1
+      assert_includes found_records, record2
+    end
+  end
+
+  test "should find records by array of numeric IDs" do
+    with_instances_of(model_class, 2) do |record1, record2|
+      ids = [record1.id, record2.id]
+      found_records = model_class.find(ids)
+      
+      assert_equal 2, found_records.size
+      assert_includes found_records, record1
+      assert_includes found_records, record2
+    end
+  end
+
+  test "should find records by mixed array of slugs and numeric IDs" do
+    with_instances_of(model_class, 2) do |record1, record2|
+      mixed_ids = [record1.friendly_id, record2.id]
+      found_records = model_class.find(mixed_ids)
+      
+      assert_equal 2, found_records.size
+      assert_includes found_records, record1
+      assert_includes found_records, record2
+    end
+  end
+
+  test "should return empty array for empty array input" do
+    result = model_class.find([])
+    assert_equal [], result
+  end
+
+  test "should raise RecordNotFound for non-existent slug in array" do
+    with_instance_of(model_class) do |record|
+      slugs = [record.friendly_id, "non-existent-slug"]
+      
+      assert_raises(ActiveRecord::RecordNotFound) do
+        model_class.find(slugs)
+      end
+    end
+  end
+
+  test "should raise RecordNotFound for non-existent ID in array" do
+    with_instance_of(model_class) do |record|
+      ids = [record.id, 99999]
+      
+      assert_raises(ActiveRecord::RecordNotFound) do
+        model_class.find(ids)
+      end
+    end
+  end
+
+  test "should raise RecordNotFound for mixed array with non-existent items" do
+    with_instance_of(model_class) do |record|
+      mixed_ids = [record.friendly_id, 99999]
+      
+      assert_raises(ActiveRecord::RecordNotFound) do
+        model_class.find(mixed_ids)
+      end
+    end
+  end
+
+  test "should return partial results with allow_nil for array with non-existent slugs" do
+    with_instance_of(model_class) do |record|
+      slugs = [record.friendly_id, "non-existent-slug"]
+      found_records = model_class.find(slugs, allow_nil: true)
+      
+      assert_equal 1, found_records.size
+      assert_includes found_records, record
+    end
+  end
+
+  test "should return partial results with allow_nil for array with non-existent IDs" do
+    with_instance_of(model_class) do |record|
+      ids = [record.id, 99999]
+      found_records = model_class.find(ids, allow_nil: true)
+      
+      assert_equal 1, found_records.size
+      assert_includes found_records, record
+    end
+  end
+
+  test "should work with array finders on relations" do
+    with_instances_of(model_class, 2) do |record1, record2|
+      slugs = [record1.friendly_id, record2.friendly_id]
+      found_records = model_class.existing.find(slugs)
+      
+      assert_equal 2, found_records.size
+      assert_includes found_records, record1
+      assert_includes found_records, record2
+    end
+  end
+
+  test "should handle array with single slug" do
+    with_instance_of(model_class) do |record|
+      found_records = model_class.find([record.friendly_id])
+      
+      assert_equal 1, found_records.size
+      assert_equal record, found_records.first
+    end
+  end
+
+  test "should handle array with single numeric ID" do
+    with_instance_of(model_class) do |record|
+      found_records = model_class.find([record.id])
+      
+      assert_equal 1, found_records.size
+      assert_equal record, found_records.first
+    end
+  end
+
+  # Helper method to create multiple instances
+  def with_instances_of(model_class, count)
+    instances = count.times.map do |i|
+      model_class.create(name: "Test Record #{i + 1}")
+    end
+    
+    yield(*instances)
+  ensure
+    instances&.each(&:destroy)
+  end
 end


### PR DESCRIPTION
Fixes #1034 
Possibly fixes #1018  (not confirmed)

## Description

This PR adds support for finding records using an array of slugs, similar to how ActiveRecord handles arrays of numeric IDs. If FriendlyId is the "Swiss Army bulldozer" of slugging plugins, this enhancement adds laser-guided precision to that bulldozer!

## Problem

Previously, while single slug lookups worked fine:
```ruby
GlossaryTerm.find("one")        # ✅ Works
GlossaryTerm.find([1, 2])       # ✅ Works (numeric IDs)
```

Array slug lookups would fail:
```ruby
GlossaryTerm.find(["one"])      # ❌ ActiveRecord::RecordNotFound
GlossaryTerm.find(["one", "two"]) # ❌ ActiveRecord::RecordNotFound
```

## Solution

Now you can find records using:

- **Array of slugs**: `GlossaryTerm.find(["one", "two"])`
- **Mixed arrays**: `GlossaryTerm.find(["one", 2, "three"])` (slugs + numeric IDs)
- **Partial results**: `GlossaryTerm.find(["one", "missing"], allow_nil: true)`
- **Relations**: `GlossaryTerm.active.find(["one", "two"])`

## Key Features

- Maintains backward compatibility
- Proper error handling with `ActiveRecord::RecordNotFound`
- Supports `allow_nil: true` for partial results
- Works with scoped relations
- Handles empty arrays gracefully
- Efficient queries (separate slug and ID lookups)

## Testing

Added comprehensive test coverage including:
- Array slug finding
- Mixed array handling
- Error cases
- Edge cases (empty arrays, single elements)
- Relation scoping
- All existing tests continue to pass

This enhancement makes FriendlyId even more developer-friendly while maintaining it's robustness.