### PR TITLE
Treat leading-zero slugs as numeric conflicts

### DIFF
--- a/lib/friendly_id/slug_generator.rb
+++ b/lib/friendly_id/slug_generator.rb
@@ -28,11 +28,8 @@ module FriendlyId
 
     def purely_numeric_slug?(slug)
       return false unless slug
-      begin
-        Integer(slug, 10).to_s == slug.to_s
-      rescue ArgumentError, TypeError
-        false
-      end
+
+      slug.to_s.match?(/\A[0-9]+\z/)
     end
   end
 end

--- a/test/numeric_slug_test.rb
+++ b/test/numeric_slug_test.rb
@@ -2,12 +2,14 @@ require "helper"
 
 class Article < ActiveRecord::Base
   extend FriendlyId
+
   friendly_id :name, use: :slugged
 end
 
 class ArticleWithNumericPrevention < ActiveRecord::Base
   self.table_name = "articles"
   extend FriendlyId
+
   friendly_id :name, use: :slugged
   friendly_id_config.treat_numeric_as_conflict = true
 end
@@ -68,6 +70,14 @@ class NumericSlugTest < TestCaseClass
       record = ArticleWithNumericPrevention.create! name: "0"
       refute_equal "0", record.slug
       assert_match(/\A0-[0-9a-f-]{36}\z/, record.slug)
+    end
+  end
+
+  test "should handle numbers with leading zeroes as numeric when treat_numeric_as_conflict is enabled" do
+    transaction do
+      record = ArticleWithNumericPrevention.create! name: "00123"
+      refute_equal "00123", record.slug
+      assert_match(/\A00123-[0-9a-f-]{36}\z/, record.slug)
     end
   end
 


### PR DESCRIPTION
Previously, numeric detection parsed the slug as an integer and compared the result, causing values such as `00123` to be treated as non-numeric. The check now matches ASCII digits directly.

Includes a regression test for leading-zero numeric slugs. (I ran into this issue when an international phone number was accidentally use as a slug)